### PR TITLE
Added support for HomeAssistant `input_button`

### DIFF
--- a/apps/nspanel-lovelance-ui/nspanel-lovelance-ui.py
+++ b/apps/nspanel-lovelance-ui/nspanel-lovelance-ui.py
@@ -290,8 +290,8 @@ class NsPanelLovelanceUI:
       value = entity.state + " " + entity.attributes.unit_of_measurement
       return "entityUpd,{0},{1},{2},{3},{4},{5}".format(item_nr, "text", item, icon_id, name, value)
 
-    if item_type == "button":
-      return "entityUpd,{0},{1},{2},{3},{4},{5}".format(item_nr, item_type, item, 3, name, "PRESS")
+    if item_type == "button" or item_type == "input_button":
+      return "entityUpd,{0},{1},{2},{3},{4},{5}".format(item_nr, "button", item, 3, name, "PRESS")
 
   def generate_thermo_page(self, item):
     entity       = self.api.get_entity(item)


### PR DESCRIPTION
I only recently started using HomeAssistant, not sure if `button` is incorrect (and can be removed) but for me at least when I create a 'helper'/button it is of type `input_button`.