### PR TITLE
Add link to custom ESPHome component to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Content of the screen is controlled by a AppDaemon Python Script installed on yo
 
 It works with [Tasmota](https://tasmota.github.io/docs/) and MQTT. 
 To control the panel and update it with content from HomeAssistant there is an [AppDaemon](https://github.com/AppDaemon/appdaemon) App.
+Alternatively there’s a third-party [ESPHome component](https://github.com/sairon/esphome-nspanel-lovelace-ui) which allows using ESPHome instead of Tasmota.
 
 See the following picture to get an idea of the look of this firmware for NSPanel.
 


### PR DESCRIPTION
Shameless plug - add link to my ESPHome component repository to the readme. The repo continues work that was started here but was later abandoned. I found it better to put it to a dedicated repo than making a pull request with the code to this repository because this way it will be easier to maintain it and all the hate when it breaks will go directly to me :)