### PR TITLE
popupShutter now also respects device_class

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -426,7 +426,8 @@ class LuiPagesGen(object):
     
     def generate_shutter_detail_page(self, entity):
         entity = self._ha_api.get_entity(entity)
-        icon_id   = get_icon_id_ha("cover", state=entity.state)
+        device_class = entity.attributes.get("device_class", "")
+        icon_id   = get_icon_id_ha("cover", state=entity.state, device_class=device_class)
 
         pos = entity.attributes.get("current_position")
         if pos is None:


### PR DESCRIPTION
generate_shutter_detail_page() now respects device_class and fetches the appropriate icon