### PR TITLE
Covers custom action icons

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/icons.py
+++ b/apps/nspanel-lovelace-ui/luibackend/icons.py
@@ -61,32 +61,71 @@ sensor_mapping = {
 }
 
 cover_mapping_open = {
-    "awning":   "window-open",
-    "blind":    "blinds-open",
-    "curtain":  "curtains-closed",
-    "damper":   "checkbox-blank-circle",
-    "door":     "door-open",
-    "garage":   "garage-open",
-    "gate":     "gate-open",
-    "shade":    "blinds-open",
-    "shutter":  "window-shutter-open",
-    "window":   "window-open"
+    "awning": "window-open",
+    "blind": "blinds-open",
+    "curtain": "curtains-closed",
+    "damper": "checkbox-blank-circle",
+    "door": "door-open",
+    "garage": "garage-open",
+    "gate": "gate-open",
+    "shade": "blinds-open",
+    "shutter": "window-shutter-open",
+    "window": "window-open"
 }
 
 cover_mapping_closed = {
-    "awning":   "window-closed",
-    "blind":    "blinds",
-    "curtain":  "curtains",
-    "damper":   "circle-slice-8",
-    "door":     "door-closed",
-    "garage":   "garage",
-    "gate":     "gate",
-    "shade":    "blinds",
-    "shutter":  "window-shutter",
-    "window":   "window-closed"
+    "awning": "window-closed",
+    "blind": "blinds",
+    "curtain": "curtains",
+    "damper": "circle-slice-8",
+    "door": "door-closed",
+    "garage": "garage",
+    "gate": "gate",
+    "shade": "blinds",
+    "shutter": "window-shutter",
+    "window": "window-closed"
 }
 
-def map_to_mdi_name(ha_type, state=None, device_class=None):
+cover_mapping_action_open = {
+    "awning":   "arrow-up",
+    "blind":    "arrow-up",
+    "curtain":  "arrow-expand-horizontal",
+    "damper":   "arrow-up",
+    "door":     "arrow-expand-horizontal",
+    "garage":   "arrow-up",
+    "gate":     "arrow-expand-horizontal",
+    "shade":    "arrow-up",
+    "shutter":  "arrow-up",
+    "window": "arrow-up"
+}
+
+cover_mapping_action_close = {
+    "awning": "arrow-down",
+    "blind": "arrow-down",
+    "curtain": "arrow-collapse-horizontal",
+    "damper": "arrow-down",
+    "door": "arrow-collapse-horizontal",
+    "garage": "arrow-down",
+    "gate": "arrow-collapse-horizontal",
+    "shade":  "arrow-down",
+    "shutter": "arrow-down",
+    "window": "arrow-down"
+}
+
+cover_mapping_action_stop = {
+    "awning": "stop",
+    "blind": "stop",
+    "curtain": "stop",
+    "damper": "stop",
+    "door": "stop",
+    "garage": "stop",
+    "gate": "stop",
+    "shade": "stop",
+    "shutter": "stop",
+    "window": "stop"
+}
+
+def map_to_mdi_name(ha_type, state=None, device_class=None, cardType=None):
     if ha_type == "weather":
         return weather_mapping[state] if state in weather_mapping else "alert-circle-outline"
     if ha_type == "button":
@@ -129,3 +168,22 @@ def get_icon_id_ha(ha_name, state=None, device_class=None, overwrite=None):
     if overwrite is not None:
         return get_icon_id(overwrite)
     return get_icon_id(map_to_mdi_name(ha_name, state, device_class))
+
+def get_action_id_ha(ha_type, action, device_class=None, overwrite=None):
+    if overwrite is not None:
+        return get_icon_id(overwrite)
+    if ha_type == "cover":
+        if device_class is None:
+            device_class = "window"
+        if action == "open":
+            actionicon = cover_mapping_action_open[device_class] if device_class in cover_mapping_action_open else "alert-circle-outline"
+        elif action == "close":
+            actionicon = cover_mapping_action_close[device_class] if device_class in cover_mapping_action_close else "alert-circle-outline"
+        elif action == "stop":
+            actionicon = cover_mapping_action_stop[device_class] if device_class in cover_mapping_action_stop else "alert-circle-outline"
+        else:
+            actionicon = "alert-circle-outline"
+    else:
+        actionicon = "alert-circle-outline"
+    return get_icon_id(actionicon)
+

--- a/apps/nspanel-lovelace-ui/luibackend/icons.py
+++ b/apps/nspanel-lovelace-ui/luibackend/icons.py
@@ -60,69 +60,18 @@ sensor_mapping = {
     "voltage": "flash"
 }
 
-cover_mapping_open = {
-    "awning": "window-open",
-    "blind": "blinds-open",
-    "curtain": "curtains-closed",
-    "damper": "checkbox-blank-circle",
-    "door": "door-open",
-    "garage": "garage-open",
-    "gate": "gate-open",
-    "shade": "blinds-open",
-    "shutter": "window-shutter-open",
-    "window": "window-open"
-}
-
-cover_mapping_closed = {
-    "awning": "window-closed",
-    "blind": "blinds",
-    "curtain": "curtains",
-    "damper": "circle-slice-8",
-    "door": "door-closed",
-    "garage": "garage",
-    "gate": "gate",
-    "shade": "blinds",
-    "shutter": "window-shutter",
-    "window": "window-closed"
-}
-
-cover_mapping_action_open = {
-    "awning":   "arrow-up",
-    "blind":    "arrow-up",
-    "curtain":  "arrow-expand-horizontal",
-    "damper":   "arrow-up",
-    "door":     "arrow-expand-horizontal",
-    "garage":   "arrow-up",
-    "gate":     "arrow-expand-horizontal",
-    "shade":    "arrow-up",
-    "shutter":  "arrow-up",
-    "window": "arrow-up"
-}
-
-cover_mapping_action_close = {
-    "awning": "arrow-down",
-    "blind": "arrow-down",
-    "curtain": "arrow-collapse-horizontal",
-    "damper": "arrow-down",
-    "door": "arrow-collapse-horizontal",
-    "garage": "arrow-down",
-    "gate": "arrow-collapse-horizontal",
-    "shade":  "arrow-down",
-    "shutter": "arrow-down",
-    "window": "arrow-down"
-}
-
-cover_mapping_action_stop = {
-    "awning": "stop",
-    "blind": "stop",
-    "curtain": "stop",
-    "damper": "stop",
-    "door": "stop",
-    "garage": "stop",
-    "gate": "stop",
-    "shade": "stop",
-    "shutter": "stop",
-    "window": "stop"
+cover_mapping = {
+    #"device_class": ("icon-open",             "icon-closed",    "icon-cover-open",         "icon-cover-stop", "icon-cover-close")
+    "awning":        ("window-open",           "window-closed",  "arrow-up",                "stop",            "arrow-down"),
+    "blind":         ("blinds-open",           "blinds",         "arrow-up",                "stop",            "arrow-down"),
+    "curtain":       ("curtains-closed",       "curtains",       "arrow-expand-horizontal", "stop",            "arrow-collapse-horizontal"),
+    "damper":        ("checkbox-blank-circle", "circle-slice-8", "arrow-up",                "stop",            "arrow-down"),
+    "door":          ("door-open",             "door-closed",    "arrow-expand-horizontal", "stop",            "arrow-collapse-horizontal"),
+    "garage":        ("garage-open",           "garage",         "arrow-up",                "stop",            "arrow-down"),
+    "gate":          ("gate-open",             "gate",           "arrow-expand-horizontal", "stop",            "arrow-collapse-horizontal"),
+    "shade":         ("blinds-open",           "blinds",         "arrow-up",                "stop",            "arrow-down"),
+    "shutter":       ("window-shutter-open",   "window-shutter", "arrow-up",                "stop",            "arrow-down"),
+    "window":        ("window-open"            "window-closed",  "arrow-up",                "stop",            "arrow-down"),
 }
 
 def map_to_mdi_name(ha_type, state=None, device_class=None, cardType=None):
@@ -148,9 +97,9 @@ def map_to_mdi_name(ha_type, state=None, device_class=None, cardType=None):
         if device_class is None:
             device_class = "window"
         if state == "closed":
-            return cover_mapping_closed[device_class] if device_class in cover_mapping_closed else "alert-circle-outline"
+            return cover_mapping[device_class][1] if device_class in cover_mapping else "alert-circle-outline"
         else:
-            return cover_mapping_open[device_class] if device_class in cover_mapping_open else "alert-circle-outline"
+            return cover_mapping[device_class][0] if device_class in cover_mapping else "alert-circle-outline"
     if ha_type == "lock":
         return "lock-open" if state == "unlocked" else "lock"
 
@@ -176,11 +125,11 @@ def get_action_id_ha(ha_type, action, device_class=None, overwrite=None):
         if device_class is None:
             device_class = "window"
         if action == "open":
-            actionicon = cover_mapping_action_open[device_class] if device_class in cover_mapping_action_open else "alert-circle-outline"
+            actionicon = cover_mapping[device_class][2] if device_class in cover_mapping else "alert-circle-outline"
         elif action == "close":
-            actionicon = cover_mapping_action_close[device_class] if device_class in cover_mapping_action_close else "alert-circle-outline"
+            actionicon = cover_mapping[device_class][4] if device_class in cover_mapping else "alert-circle-outline"
         elif action == "stop":
-            actionicon = cover_mapping_action_stop[device_class] if device_class in cover_mapping_action_stop else "alert-circle-outline"
+            actionicon = cover_mapping[device_class][3] if device_class in cover_mapping else "alert-circle-outline"
         else:
             actionicon = "alert-circle-outline"
     else:

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -3,6 +3,7 @@ import dateutil.parser as dp
 
 from icon_mapping import get_icon_id
 from icons import get_icon_id_ha
+from icons import get_action_id_ha
 from helper import scale, rgb_dec565, rgb_brightness, get_attr_safe, convert_temperature
 from localization import get_translation
 
@@ -146,9 +147,9 @@ class LuiPagesGen(object):
 
             device_class = entity.attributes.get("device_class", "")
             icon_id = get_icon_id_ha("cover", state=entity.state, device_class=device_class, overwrite=icon)
-            icon_up   = get_icon_id("arrow-up")
-            icon_stop = get_icon_id("stop")
-            icon_down = get_icon_id("arrow-down")
+            icon_up   = get_action_id_ha(ha_type="cover", action="open", device_class=device_class)
+            icon_stop = get_action_id_ha(ha_type="cover", action="stop", device_class=device_class)
+            icon_down = get_action_id_ha(ha_type="cover", action="close", device_class=device_class)
             
             pos = int(entity.attributes.get("current_position", 50))
             if pos == 100:
@@ -440,14 +441,19 @@ class LuiPagesGen(object):
             pos_status = pos
 
         
-        icon_up   = get_icon_id("arrow-up")
-        icon_stop = get_icon_id("stop")
-        icon_down = get_icon_id("arrow-down")
+        icon_up   = get_action_id_ha(ha_type="cover", action="open", device_class=device_class)
+        icon_stop = get_action_id_ha(ha_type="cover", action="stop", device_class=device_class)
+        icon_down = get_action_id_ha(ha_type="cover", action="close", device_class=device_class)
 
         if pos == 100:
             icon_up = "disable"
         elif pos == 0:
             icon_down = "disable"
+        elif pos == "disable":
+            if pos_status == "open":
+                icon_up = "disable"
+            elif pos_status == "closed":
+                icon_down = "disable"
 
         pos_translation = get_translation(self._locale, "position")
         self._send_mqtt_msg(f"entityUpdateDetail~{pos}~{pos_translation}: {pos_status}~{pos_translation}~{icon_id}~{icon_up}~{icon_stop}~{icon_down}")


### PR DESCRIPTION
Created get_action_id_ha() which returns the appropriate action icon.

Notes: 

- only works for covers for now but there is flexibility to define new ha_types in the future.
- `overwrite` is a placeholder for now but might be used in apps.yaml in the future to overwrite these action icons.
- retains "disable" actions but this is slightly visually jarring where custom action icons are used because a greyed arrow-down may be next to an arrow-expand-horizontal

Changes to pages.py to use get_action_id_ha().