### PR TITLE
Differentiate media page error and off icons

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -290,7 +290,7 @@ class LuiPagesGen(object):
         else:
             entity        = self._ha_api.get_entity(item)
             heading       = entity.attributes.friendly_name
-            icon          = get_icon_id('alert-circle-outline')
+            icon          = get_icon_id('speaker-off')
             title         = get_attr_safe(entity, "media_title", "")
             author        = get_attr_safe(entity, "media_artist", "")
             volume        = int(get_attr_safe(entity, "volume_level", 0)*100)


### PR DESCRIPTION
Media page now shows `speaker-off` when the speaker is off instead of an error icon.