### PR TITLE
Screensaver Themes Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,29 +477,29 @@ This only works for the screensaver currently.
 
 key | option | type | default | description
 -- | -- | -- | -- | --
-`background` | True | string | 0 (Black) | RGB565 color
-`time` | True | string | 65535 (White) | RGB565 color
-`timeAMPM` | True | string | 65535 (White) | RGB565 color
-`date` | True | string | 65535 (White) | RGB565 color
-`tMainIcon` | True | string | 65535 (White) | RGB565 color
-`tMainText` | True | string | 65535 (White) | RGB565 color
-`tForecast1` | True | string | 65535 (White) | RGB565 color
-`tForecast2` | True | string | 65535 (White) | RGB565 color
-`tForecast3` | True | string | 65535 (White) | RGB565 color
-`tForecast4` | True | string | 65535 (White) | RGB565 color
-`tF1Icon` | True | string | 65535 (White) | RGB565 color
-`tF2Icon` | True | string | 65535 (White) | RGB565 color
-`tForecast1Val` | True | string | 65535 (White) | RGB565 color
-`tForecast2Val` | True | string | 65535 (White) | RGB565 color
-`tForecast3Val` | True | string | 65535 (White) | RGB565 color
-`tForecast4Val` | True | string | 65535 (White) | RGB565 color
-`bar` | True | string | 65535 (White) | RGB565 color
-`tMainIconAlt` | True | string | 65535 (White) | RGB565 color
-`tMainTextAlt` | True | string | 65535 (White) | RGB565 color
-`tMRIcon` | True | string | 65535 (White) | RGB565 color
-`tMR` | True | string | 65535 (White) | RGB565 color
+`background` | True | list | Black | `[R, G, B]`
+`time` | True | list | White | `[R, G, B]`
+`timeAMPM` | True | list | White | `[R, G, B]`
+`date` | True | list | White | `[R, G, B]`
+`tMainIcon` | True | list | White | `[R, G, B]`
+`tMainText` | True | list | White | `[R, G, B]`
+`tForecast1` | True | list | White | `[R, G, B]`
+`tForecast2` | True | list | White | `[R, G, B]`
+`tForecast3` | True | list | White | `[R, G, B]`
+`tForecast4` | True | list | White | `[R, G, B]`
+`tF1Icon` | True | list | White | `[R, G, B]`
+`tF2Icon` | True | list | White | `[R, G, B]`
+`tForecast1Val` | True | list | White | `[R, G, B]`
+`tForecast2Val` | True | list | White | `[R, G, B]`
+`tForecast3Val` | True | list | White | `[R, G, B]`
+`tForecast4Val` | True | list | White | `[R, G, B]`
+`bar` | True | list | White | `[R, G, B]`
+`tMainIconAlt` | True | list | White | `[R, G, B]`
+`tMainTextAlt` | True | list | White | `[R, G, B]`
+`tMRIcon` | True | list | White | `[R, G, B]`
+`tMR` | True | list | White | `[R, G, B]`
 
-RGB565 colors must be specified as decimal (not hex) RGB565 color. Valid colors range from 0-65535 (0x0000-0xFFFF hex).
+Specify colours as red green and blue values from 0-255 e.g. `[255, 0, 0]` for red ir `[0, 0, 255]` for blue. These are translated internally to RGB565 (note that this has lower color depth so the colours may not appear the same).
 
 #### Schedule sleep brightness
 

--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ key | option | type | default | description
 `tForecast4` | True | list | White | `[R, G, B]`
 `tF1Icon` | True | list | White | `[R, G, B]`
 `tF2Icon` | True | list | White | `[R, G, B]`
+`tF3Icon` | True | list | White | `[R, G, B]`
+`tF4Icon` | True | list | White | `[R, G, B]`
 `tForecast1Val` | True | list | White | `[R, G, B]`
 `tForecast2Val` | True | list | White | `[R, G, B]`
 `tForecast3Val` | True | list | White | `[R, G, B]`
@@ -498,8 +500,9 @@ key | option | type | default | description
 `tMainTextAlt` | True | list | White | `[R, G, B]`
 `tMRIcon` | True | list | White | `[R, G, B]`
 `tMR` | True | list | White | `[R, G, B]`
+`AutoWeather` | True | string | None | Set to `auto` to enable weather icons to change depending on state e.g. blue for rainy. Any custom colors in `tMainIcon` `tF1Icon` `tF2Icon` `tF3Icon` `tF4Icon` take precedence
 
-Specify colours as red green and blue values from 0-255 e.g. `[255, 0, 0]` for red ir `[0, 0, 255]` for blue. These are translated internally to RGB565 (note that this has lower color depth so the colours may not appear the same).
+Specify colours as red green and blue values from 0-255 e.g. `[255, 0, 0]` for red or `[0, 0, 255]` for blue. These are translated internally to RGB565 (note that this has lower color depth so the colours may not appear the same). Also note that the screen has a low contrast ratio, so colors look sigificantly different at full display brightness and lowest brightness.
 
 #### Schedule sleep brightness
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ key | optional | type | default | description
 `dateAdditonalTemplate` | True | string | `" - {{ states('sun.sun') }}"` | Addional Text dispayed after Date, can contain Homeassistant Templates
 `dateFormat` | True | string | `%A, %d. %B %Y` | date format used if babel is not installed
 `cards` | False | complex | | configuration for cards that are displayed on panel
+`theme` | True | complex | | configuration for theme
 `screensaver` | True | complex | | configuration for screensaver
 `hiddenCards` | True | complex | | configuration for cards that can be accessed though navigate items
 
@@ -461,7 +462,6 @@ key | optional | type | default | description
 `alternativeLayout` | True | boolean | `False` | alternative layout with humidity
 `defaultCard` | True | string | `None` | default page after exiting screensaver; only works with top level cards defined in cards; needs to be a navigation item, see subpages (navigate.type_key) This config option will also be evaluated as a HomeAssistant Template.
 `key` | True | string | `None` | Used by navigate items
-`color` | True | string | `None` | Used to change the default coloring on the screensaver. The color for each element is set seperately and must be specified as a decimal (not hex) RGB565 color. Valid colors range from 0-65535 (0x0000-0xFFFF hex). Format is: `background~time~timeAMPM~date~tMainIcon~tMainText~tForecast1~tForecast2~tForecast3~tForecast4~tF1Icon~tF2Icon~tF3Icon~tF4Icon~tForecast1Val~tForecast2Val~tForecast3Val~tForecast4Val~bar~tMainIconAlt~tMainTextAlt~tMRIcon~tMR`
 
 Example for the weatherOverride config options:
 
@@ -471,12 +471,35 @@ Example for the weatherOverride config options:
         name: name
         icon: lightbulb
 ```
+#### Possible configuration values for theme config
 
-Example for color config option:
-```yaml
-   color: 111~222~333~444~555~666~777~888~999~1111~2222~3333~4444~5555~6666~7777~8888~9999~11111~22222~33333~44444~55555
-```
-N.B. This generates a nonsensical color scheme and should not be used.
+This only works for the screensaver currently.
+
+key | option | type | default | description
+-- | -- | -- | -- | --
+`background` | True | string | 0 (Black) | RGB565 color
+`time` | True | string | 65535 (White) | RGB565 color
+`timeAMPM` | True | string | 65535 (White) | RGB565 color
+`date` | True | string | 65535 (White) | RGB565 color
+`tMainIcon` | True | string | 65535 (White) | RGB565 color
+`tMainText` | True | string | 65535 (White) | RGB565 color
+`tForecast1` | True | string | 65535 (White) | RGB565 color
+`tForecast2` | True | string | 65535 (White) | RGB565 color
+`tForecast3` | True | string | 65535 (White) | RGB565 color
+`tForecast4` | True | string | 65535 (White) | RGB565 color
+`tF1Icon` | True | string | 65535 (White) | RGB565 color
+`tF2Icon` | True | string | 65535 (White) | RGB565 color
+`tForecast1Val` | True | string | 65535 (White) | RGB565 color
+`tForecast2Val` | True | string | 65535 (White) | RGB565 color
+`tForecast3Val` | True | string | 65535 (White) | RGB565 color
+`tForecast4Val` | True | string | 65535 (White) | RGB565 color
+`bar` | True | string | 65535 (White) | RGB565 color
+`tMainIconAlt` | True | string | 65535 (White) | RGB565 color
+`tMainTextAlt` | True | string | 65535 (White) | RGB565 color
+`tMRIcon` | True | string | 65535 (White) | RGB565 color
+`tMR` | True | string | 65535 (White) | RGB565 color
+
+RGB565 colors must be specified as decimal (not hex) RGB565 color. Valid colors range from 0-65535 (0x0000-0xFFFF hex).
 
 #### Schedule sleep brightness
 

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -1,6 +1,7 @@
 import datetime
 import dateutil.parser as dp
 
+from theme import get_screensaver_color_output
 from icon_mapping import get_icon_id
 from icons import get_icon_id_ha
 from icons import get_action_id_ha
@@ -419,10 +420,10 @@ class LuiPagesGen(object):
             self.generate_alarm_page(navigation, card.entity)
         if card.cardType == "screensaver":
             self.update_screensaver_weather()
-            # send color if configured in screensaver
-            color = card.raw_config.get("color")
-            if color is not None:
-                self._send_mqtt_msg(f"color~{color}")
+            # send color if configured in theme
+            theme = self._config.get("theme")
+            if theme is not None:
+                self._send_mqtt_msg(get_screensaver_color_output(theme))
         if card.cardType == "cardQR":
             qrcode = card.raw_config.get("qrCode", "")
             self.generate_qr_page(navigation, card.title, card.entities, card.cardType, qrcode)

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -131,9 +131,7 @@ class LuiPagesGen(object):
         # send color if configured in screensaver
         theme = self._config.get("theme")
         if theme is not None:
-            if "AutoWeather" in theme and theme["AutoWeather"] == "auto":
-                # do nothing
-            else:
+            if not ("AutoWeather" in theme and theme["AutoWeather"] == "auto"):
                 state = None
             self._send_mqtt_msg(get_screensaver_color_output(theme=theme, state=state))
 

--- a/apps/nspanel-lovelace-ui/luibackend/theme.py
+++ b/apps/nspanel-lovelace-ui/luibackend/theme.py
@@ -2,7 +2,7 @@
 default_screensaver_color_mapping = {
     #"item":            "color in decimal RGB565 (1-65535)"
     "background":       "0",
-    "time":             "1111",
+    "time":             "65535",
     "timeAMPM":         "65535",
     "date":             "65535",
     "tMainIcon":         "65535",

--- a/apps/nspanel-lovelace-ui/luibackend/theme.py
+++ b/apps/nspanel-lovelace-ui/luibackend/theme.py
@@ -2,25 +2,25 @@
 from helper import rgb_dec565
 
 default_screensaver_color_mapping = {
-    #"item":            "color in decimal RGB565 (1-65535)"
+    #"item":            "color in decimal RGB565 (0-65535)"
     "background":       "0",
     "time":             "65535",
     "timeAMPM":         "65535",
     "date":             "65535",
-    "tMainIcon":         "65535",
-    "tMainText":         "65535",
-    "tForecast1":        "65535",
-    "tForecast2":        "65535",
-    "tForecast3":        "65535",
-    "tForecast4":        "65535",
-    "tF1Icon":           "65535",
-    "tF2Icon":           "65535",
-    "tF3Icon":           "65535",
-    "tF4Icon":           "65535",
-    "tForecast1Val":     "65535",
-    "tForecast2Val":     "65535",
-    "tForecast3Val":     "65535",
-    "tForecast4Val":     "65535",
+    "tMainIcon":        "65535",
+    "tMainText":        "65535",
+    "tForecast1":       "65535",
+    "tForecast2":       "65535",
+    "tForecast3":       "65535",
+    "tForecast4":       "65535",
+    "tF1Icon":          "65535",
+    "tF2Icon":          "65535",
+    "tF3Icon":          "65535",
+    "tF4Icon":          "65535",
+    "tForecast1Val":    "65535",
+    "tForecast2Val":    "65535",
+    "tForecast3Val":    "65535",
+    "tForecast4Val":    "65535",
     "bar":              "65535",
     "tMainIconAlt":     "65535",
     "tMainTextAlt":     "65535",
@@ -29,7 +29,7 @@ default_screensaver_color_mapping = {
 }
 
 default_weather_icon_color_mapping = {
-    #"item-per HA"             "color in decimal RGB 565 (1-65535)"
+    #"item-per HA"             "color in decimal RGB 565 (0-65535)"
     "clear-night":              "35957", #50% grey
     "cloudy":                   "31728", #grey-blue
     "exceptional":              "63488", #red
@@ -38,7 +38,7 @@ default_weather_icon_color_mapping = {
     "lightning":                "65120", #golden-yellow
     "lightning-rainy":          "50400", #dark-golden-yellow
     "partlycloudy":             "35957", #50% grey
-    "pouring":                  "249", #blue
+    "pouring":                  "249",   #blue
     "rainy":                    "33759", #light-blue
     "snowy":                    "65535", #white
     "snowy-rainy":              "44479", #light-blue-grey
@@ -60,10 +60,9 @@ def map_color(key, theme, state=None):
         config_color = rgb_dec565(theme[key])
 #   Use Autocolouring for weather
     elif state is not None:
-        if key == "tMainIcon" or key == "tF1Icon" or key == "tF2Icon" or key == "tF3Icon" or key == "tF4Icon":
+        if key in ["tMainIcon", "tF1Icon", "tF2Icon", "tF3Icon", "tF4Icon"]:
             config_color = map_weather_icon_color(key=key, state=state)
     return config_color
-
 
 def map_weather_icon_color(key, state):
     if state[key] in default_weather_icon_color_mapping:

--- a/apps/nspanel-lovelace-ui/luibackend/theme.py
+++ b/apps/nspanel-lovelace-ui/luibackend/theme.py
@@ -1,4 +1,6 @@
 
+from helper import rgb_dec565
+
 default_screensaver_color_mapping = {
     #"item":            "color in decimal RGB565 (1-65535)"
     "background":       "0",
@@ -13,8 +15,8 @@ default_screensaver_color_mapping = {
     "tForecast4":        "65535",
     "tF1Icon":           "65535",
     "tF2Icon":           "65535",
-    "tf3Icon":           "65535",
-    "tf4Icon":           "65535",
+    "tF3Icon":           "65535",
+    "tF4Icon":           "65535",
     "tForecast1Val":     "65535",
     "tForecast2Val":     "65535",
     "tForecast3Val":     "65535",
@@ -26,17 +28,46 @@ default_screensaver_color_mapping = {
     "tMR":              "65535"
 }
 
+default_weather_icon_color_mapping = {
+    #"item-per HA"             "color in decimal RGB 565 (1-65535)"
+    "clear-night":              "35957", #50% grey
+    "cloudy":                   "31728", #grey-blue
+    "exceptional":              "63488", #red
+    "fog":                      "21130", #75% grey
+    "hail":                     "65535", #white
+    "lightning":                "65120", #golden-yellow
+    "lightning-rainy":          "50400", #dark-golden-yellow
+    "partlycloudy":             "35957", #50% grey
+    "pouring":                  "249", #blue
+    "rainy":                    "33759", #light-blue
+    "snowy":                    "65535", #white
+    "snowy-rainy":              "44479", #light-blue-grey
+    "sunny":                    "63469", #bright-yellow
+    "windy":                    "35957", #50% grey
+    "windy-variant":            "35957"  #50% grey
+}
 
-def map_color(key, theme= None, state=None):
-#    read theme for override
-    if theme is not None and key in theme:
-        config_color = theme[key]
-    else:
-        config_color = default_screensaver_color_mapping[key]
-    return config_color
-
-def get_screensaver_color_output(theme=None):
+def get_screensaver_color_output(theme, state=None):
     color_output = "color"
     for key in default_screensaver_color_mapping:
-        color_output += f"~{map_color(key=key, theme=theme)}"
+        color_output += f"~{map_color(key=key, theme=theme, state=state)}"
     return color_output
+
+def map_color(key, theme, state=None):
+    config_color = default_screensaver_color_mapping[key]
+#   Use theme color if set
+    if key in theme:
+        config_color = rgb_dec565(theme[key])
+#   Use Autocolouring for weather
+    elif state is not None:
+        if key == "tMainIcon" or key == "tF1Icon" or key == "tF2Icon" or key == "tF3Icon" or key == "tF4Icon":
+            config_color = map_weather_icon_color(key=key, state=state)
+    return config_color
+
+
+def map_weather_icon_color(key, state):
+    if state[key] in default_weather_icon_color_mapping:
+        config_color = default_weather_icon_color_mapping[state[key]]
+    else:
+        config_color = "65535"
+    return config_color

--- a/apps/nspanel-lovelace-ui/luibackend/theme.py
+++ b/apps/nspanel-lovelace-ui/luibackend/theme.py
@@ -33,6 +33,7 @@ def map_color(key, theme= None, state=None):
         config_color = theme[key]
     else:
         config_color = default_screensaver_color_mapping[key]
+    return config_color
 
 def get_screensaver_color_output(theme=None):
     color_output = "color"

--- a/apps/nspanel-lovelace-ui/luibackend/theme.py
+++ b/apps/nspanel-lovelace-ui/luibackend/theme.py
@@ -1,0 +1,41 @@
+
+default_screensaver_color_mapping = {
+    #"item":            "color in decimal RGB565 (1-65535)"
+    "background":       "0",
+    "time":             "1111",
+    "timeAMPM":         "65535",
+    "date":             "65535",
+    "tMainIcon":         "65535",
+    "tMainText":         "65535",
+    "tForecast1":        "65535",
+    "tForecast2":        "65535",
+    "tForecast3":        "65535",
+    "tForecast4":        "65535",
+    "tF1Icon":           "65535",
+    "tF2Icon":           "65535",
+    "tf3Icon":           "65535",
+    "tf4Icon":           "65535",
+    "tForecast1Val":     "65535",
+    "tForecast2Val":     "65535",
+    "tForecast3Val":     "65535",
+    "tForecast4Val":     "65535",
+    "bar":              "65535",
+    "tMainIconAlt":     "65535",
+    "tMainTextAlt":     "65535",
+    "tMRIcon":          "65535",
+    "tMR":              "65535"
+}
+
+
+def map_color(key, theme= None, state=None):
+#    read theme for override
+    if theme is not None and key in theme:
+        config_color = theme[key]
+    else:
+        config_color = default_screensaver_color_mapping[key]
+
+def get_screensaver_color_output(theme=None):
+    color_output = "color"
+    for key in default_screensaver_color_mapping:
+        color_output += f"~{map_color(key=key, theme=theme)}"
+    return color_output


### PR DESCRIPTION
Created a new "theme" config in apps.yaml.

get_screensaver_color_output() in theme.py generates colors for this output or falls back to the default_screensaver_color_mapping if not configured in apps.yaml.

