### PR TITLE
Illuzn patch status patch

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -179,7 +179,10 @@ class LuiPagesGen(object):
                 else:
                     icon_color = 17299
                 if icon is not None:
-                    icon_id = get_icon_id_ha("sensor", state=status_entity.state, overwrite=icon)
+                    if status_entity is not None:
+                        icon_id = get_icon_id_ha("sensor", state=status_entity.state, overwrite=icon)
+                    else:
+                        icon_id = get_icon_id(icon)
                 return f"~button~{entityId}~{icon_id}~{icon_color}~{name}~{text}"
             else:
                 return f"~text~{entityId}~{get_icon_id('alert-circle-outline')}~17299~page not found~"

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -165,32 +165,28 @@ class LuiPagesGen(object):
         if entityType == "navigate":
             page_search_res = self._config.searchCard(entityId)
             if page_search_res is not None:
-                icon_id = get_icon_id("gesture-tap-button")
+                icon_res = get_icon_id(icon) if icon is not None else get_icon_id("gesture-tap-button")
                 status_entity = None
                 name = name if name is not None else page_search_res.title
                 text = get_translation(self._locale, "frontend.ui.card.button.press")
                 if item.status is not None and self._ha_api.entity_exists(item.status):
                     status_entity = self._ha_api.get_entity(item.status)
+                    icon_res = get_icon_id_ha("sensor", state=status_entity.state, device_class=status_entity.attributes.get("device_class", "_"), overwrite=icon)
                     icon_color = self.get_entity_color(status_entity)
                     if item.status.startswith("sensor") and cardType == "cardGrid":
-                        icon_id = status_entity.state[:4]
-                        if icon_id[-1] == ".":
-                            icon_id = icon_id[:-1]
+                        icon_res = status_entity.state[:4]
+                        if icon_res[-1] == ".":
+                            icon_res = icon_res[:-1]
                 else:
                     icon_color = 17299
-                if icon is not None:
-                    if status_entity is not None:
-                        icon_id = get_icon_id_ha("sensor", state=status_entity.state, overwrite=icon)
-                    else:
-                        icon_id = get_icon_id(icon)
-                return f"~button~{entityId}~{icon_id}~{icon_color}~{name}~{text}"
+                return f"~button~{entityId}~{icon_res}~{icon_color}~{name}~{text}"
             else:
                 return f"~text~{entityId}~{get_icon_id('alert-circle-outline')}~17299~page not found~"
         if entityType == "iText":
                 value   = entityId.split(".", 2)[1]
                 name = name if name is not None else "conf name missing"
                 icon_id = get_icon_id(icon) if icon is not None else get_icon_id("alert-circle-outline")
-                return f"~text~{entityId}~{icon_id}~17299~{name}~{value}"
+                return f"~text~{entityId}~{icon_res}~17299~{name}~{value}"
         if not self._ha_api.entity_exists(entityId):
             return f"~text~{entityId}~{get_icon_id('alert-circle-outline')}~17299~Not found check~ apps.yaml"
         

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -167,7 +167,7 @@ class LuiPagesGen(object):
             if page_search_res is not None:
                 name = name if name is not None else page_search_res.title
                 text = get_translation(self._locale, "frontend.ui.card.button.press")
-                icon_id = get_icon_id(icon) if icon is not None else get_icon_id("gesture-tap-button")
+                status_entity = None
                 if item.status is not None and self._ha_api.entity_exists(item.status):
                     status_entity = self._ha_api.get_entity(item.status)
                     icon_color = self.get_entity_color(status_entity)
@@ -177,6 +177,7 @@ class LuiPagesGen(object):
                             icon_id = icon_id[:-1]
                 else:
                     icon_color = 17299
+                icon_id = get_icon_id_ha("sensor", state=status_entity.state, overwrite=icon) if icon is not None else get_icon_id("gesture-tap-button")
                 return f"~button~{entityId}~{icon_id}~{icon_color}~{name}~{text}"
             else:
                 return f"~text~{entityId}~{get_icon_id('alert-circle-outline')}~17299~page not found~"

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -171,7 +171,7 @@ class LuiPagesGen(object):
                 text = get_translation(self._locale, "frontend.ui.card.button.press")
                 if item.status is not None and self._ha_api.entity_exists(item.status):
                     status_entity = self._ha_api.get_entity(item.status)
-                    icon_res = get_icon_id_ha("sensor", state=status_entity.state, device_class=status_entity.attributes.get("device_class", "_"), overwrite=icon)
+                    icon_res = get_icon_id_ha(item.status.split(".")[0], state=status_entity.state, device_class=status_entity.attributes.get("device_class", "_"), overwrite=icon)
                     icon_color = self.get_entity_color(status_entity)
                     if item.status.startswith("sensor") and cardType == "cardGrid":
                         icon_res = status_entity.state[:4]

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -185,7 +185,7 @@ class LuiPagesGen(object):
         if entityType == "iText":
                 value   = entityId.split(".", 2)[1]
                 name = name if name is not None else "conf name missing"
-                icon_id = get_icon_id(icon) if icon is not None else get_icon_id("alert-circle-outline")
+                icon_res = get_icon_id(icon) if icon is not None else get_icon_id("alert-circle-outline")
                 return f"~text~{entityId}~{icon_res}~17299~{name}~{value}"
         if not self._ha_api.entity_exists(entityId):
             return f"~text~{entityId}~{get_icon_id('alert-circle-outline')}~17299~Not found check~ apps.yaml"

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -165,9 +165,10 @@ class LuiPagesGen(object):
         if entityType == "navigate":
             page_search_res = self._config.searchCard(entityId)
             if page_search_res is not None:
+                icon_id = get_icon_id("gesture-tap-button")
+                status_entity = None
                 name = name if name is not None else page_search_res.title
                 text = get_translation(self._locale, "frontend.ui.card.button.press")
-                status_entity = None
                 if item.status is not None and self._ha_api.entity_exists(item.status):
                     status_entity = self._ha_api.get_entity(item.status)
                     icon_color = self.get_entity_color(status_entity)
@@ -177,7 +178,8 @@ class LuiPagesGen(object):
                             icon_id = icon_id[:-1]
                 else:
                     icon_color = 17299
-                icon_id = get_icon_id_ha("sensor", state=status_entity.state, overwrite=icon) if icon is not None else get_icon_id("gesture-tap-button")
+                if icon is not None:
+                    icon_id = get_icon_id_ha("sensor", state=status_entity.state, overwrite=icon)
                 return f"~button~{entityId}~{icon_id}~{icon_color}~{name}~{text}"
             else:
                 return f"~text~{entityId}~{get_icon_id('alert-circle-outline')}~17299~page not found~"


### PR DESCRIPTION
Where an entity has `state:` defined,  this allows the icon to be overridden using the `icon:` configuration [here](https://docs.nspanel.pky.eu/entities/#override-icons-or-names).

This is useful for sensors which display a state output e.g. "heating", "cooling", etc.

This should also work where `state:` points to an entity *other* than a sensor e.g. this also seems to work for my cardThermo card which points to my A/C with the following config:
````yaml
          - entity: navigate.cardThermo_AirConditioning
            status: climate.air_conditioning_control
            icon:
              "heat": mdi:fire
              "cool": mdi:snowflake
              "off": mdi:power
````