### PR TITLE
use "set_position" on "Supported Features" for cover

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -241,17 +241,27 @@ class LuiPagesGen(object):
                 pos = "disable"
             else:
                 pos_status = pos
-            if bits & 0b00000001: # SUPPORT_OPEN
-                if pos != 100 and not (entity.state == "open" and pos == "disable"):
-                    icon_up_status = "enable"
+
+            if bits & 0b00000100: # SUPPORT_SET_POSITION
+                if bits & 0b00000001: # SUPPORT_OPEN
+                    if pos != 100 and not (entity.state == "open" and pos == "disable"):
+                        icon_up_status = "enable"
+                    icon_up   = get_action_id_ha(ha_type=entityType, action="open", device_class=device_class)
+                if bits & 0b00000010: # SUPPORT_CLOSE
+                    if pos != 0 and not (entity.state == "closed" and pos == "disable"):
+                        icon_down_status = "enable"
+                    icon_down = get_action_id_ha(ha_type=entityType, action="close", device_class=device_class)
+                if bits & 0b00001000: # SUPPORT_STOP
+                    icon_stop = get_action_id_ha(ha_type=entityType, action="stop", device_class=device_class)
+                    icon_stop_status = "enable"
+            else:
+                icon_up_status = "enable"
                 icon_up   = get_action_id_ha(ha_type=entityType, action="open", device_class=device_class)
-            if bits & 0b00000010: # SUPPORT_CLOSE
-                if pos != 0 and not (entity.state == "closed" and pos == "disable"):
-                    icon_down_status = "enable"
-                icon_down = get_action_id_ha(ha_type=entityType, action="close", device_class=device_class)
-            if bits & 0b00001000: # SUPPORT_STOP
-                icon_stop = get_action_id_ha(ha_type=entityType, action="stop", device_class=device_class)
                 icon_stop_status = "enable"
+                icon_stop = get_action_id_ha(ha_type=entityType, action="stop", device_class=device_class)
+                icon_down_status = "enable"
+                icon_down = get_action_id_ha(ha_type=entityType, action="close", device_class=device_class)
+
 
             return f"~shutter~{entityId}~{icon_id}~17299~{name}~{icon_up}|{icon_stop}|{icon_down}|{icon_up_status}|{icon_stop_status}|{icon_down_status}"
         if entityType in "light":
@@ -631,18 +641,27 @@ class LuiPagesGen(object):
         # position supported
         if bits & 0b00001111:
             pos_translation = get_translation(self._locale, "frontend.ui.card.cover.position")
-        if bits & 0b00000001: # SUPPORT_OPEN
-            if pos != 100 and not (entity.state == "open" and pos == "disable"):
-                icon_up_status = "enable"
+
+        if bits & 0b00000100: # SUPPORT_SET_POSITION
+            if bits & 0b00000001: # SUPPORT_OPEN
+                if pos != 100 and not (entity.state == "open" and pos == "disable"):
+                    icon_up_status = "enable"
+                icon_up   = get_action_id_ha(ha_type=entityType, action="open", device_class=device_class)
+            if bits & 0b00000010: # SUPPORT_CLOSE
+                if pos != 0 and not (entity.state == "closed" and pos == "disable"):
+                    icon_down_status = "enable"
+                icon_down = get_action_id_ha(ha_type=entityType, action="close", device_class=device_class)
+            if bits & 0b00001000: # SUPPORT_STOP
+                icon_stop = get_action_id_ha(ha_type=entityType, action="stop", device_class=device_class)
+                icon_stop_status = "enable"
+        else:
+            icon_up_status = "enable"
             icon_up   = get_action_id_ha(ha_type=entityType, action="open", device_class=device_class)
-        if bits & 0b00000010: # SUPPORT_CLOSE
-            if pos != 0 and not (entity.state == "closed" and pos == "disable"):
-                icon_down_status = "enable"
-            icon_down = get_action_id_ha(ha_type=entityType, action="close", device_class=device_class)
-        #if bits & 0b00000100: # SUPPORT_SET_POSITION
-        if bits & 0b00001000: # SUPPORT_STOP
-            icon_stop = get_action_id_ha(ha_type=entityType, action="stop", device_class=device_class)
             icon_stop_status = "enable"
+            icon_stop = get_action_id_ha(ha_type=entityType, action="stop", device_class=device_class)
+            icon_down_status = "enable"
+            icon_down = get_action_id_ha(ha_type=entityType, action="close", device_class=device_class)
+
 
         # tilt supported
         if bits & 0b11110000:


### PR DESCRIPTION
first, hello, and thanks for your work !

I have somfy cover, with rflink use RF.
So is difficult to a have correct position of my cover. I added just one door sensor to dtect closed shutter.



My configuration.yaml looks-like to this:
<img width="412" alt="Screenshot 2022-08-19 at 16 33 33" src="https://user-images.githubusercontent.com/71899/185642358-51bee38f-6675-4c91-ae98-6db220daf767.png">


```
  - platform: template
    covers:
      volets_extension:
        device_class: shutter
        friendly_name: "Volets Extension"
        optimistic: false
        position_template: >-
          {% if is_state('binary_sensor.volets_extension', 'on') %}
          100
          {% else %}
          0
          {% endif %}
        open_cover:
          service: mqtt.publish
          data_template:
            topic: rflink/cmd
            payload: "10;EV1527;0add79;08;ON"
        close_cover:
          service: mqtt.publish
          data_template:
            topic: rflink/cmd
            payload: "10;EV1527;0add79;02;ON"
        stop_cover:
          service: mqtt.publish
          data_template:
            topic: rflink/cmd
            payload: "10;EV1527;0add79;04;ON"
```

So with optmistic=false I can't use position, but with position template I know if my shutter is closed.

Without this patch, I can't open (or closed) my shutter from NSpanel when my shutter is in the middle.

I test this on latest stable


