### PR TITLE
List of supported modes in config for Alarm Panel

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -447,7 +447,7 @@ class LuiPagesGen(object):
             command = f"entityUpd~{heading}~{navigation}~{item}~{icon}~{title}~{author}~{volume}~{iconplaypause}~{source}~{speakerlist[:200]}~{onoffbutton}~{mediaBtn}"
         self._send_mqtt_msg(command)
         
-    def generate_alarm_page(self, navigation, entity, alarmBtn):
+    def generate_alarm_page(self, navigation, entity, supported_features, alarmBtn):
         item = entity.entityId
         if not self._ha_api.entity_exists(item):
             command = f"entityUpd~{item}~{navigation}~Not found~Not found~Check your~Check your~apps.~apps.~yaml~yaml~0~~0"
@@ -462,7 +462,10 @@ class LuiPagesGen(object):
                 icon = get_icon_id("shield-off")
                 if not entity.attributes.get("code_arm_required", False):
                     numpad = "disable"
-                bits = entity.attributes.supported_features
+                if supported_features is not None:
+                    bits = supported_features
+                else:
+                    bits = entity.attributes.supported_features
                 if bits & 0b000001:
                     supported_modes.append("arm_home")
                 if bits & 0b000010:
@@ -556,6 +559,7 @@ class LuiPagesGen(object):
             self.generate_media_page(navigation, card.title, card.entity, mediaBtn)
         if card.cardType == "cardAlarm":
             alarmBtn = card.raw_config.get("alarmControl")
+            supported_features = card.raw_config.get("supportedFeatures")
             self.generate_alarm_page(navigation, card.entity, alarmBtn)
         if card.cardType == "screensaver":
             theme = card.raw_config.get("theme")

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -560,7 +560,7 @@ class LuiPagesGen(object):
         if card.cardType == "cardAlarm":
             alarmBtn = card.raw_config.get("alarmControl")
             supported_features = card.raw_config.get("supportedFeatures")
-            self.generate_alarm_page(navigation, card.entity, alarmBtn)
+            self.generate_alarm_page(navigation, card.entity, supported_features, alarmBtn)
         if card.cardType == "screensaver":
             theme = card.raw_config.get("theme")
             self.update_screensaver_weather(theme)

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -447,7 +447,7 @@ class LuiPagesGen(object):
             command = f"entityUpd~{heading}~{navigation}~{item}~{icon}~{title}~{author}~{volume}~{iconplaypause}~{source}~{speakerlist[:200]}~{onoffbutton}~{mediaBtn}"
         self._send_mqtt_msg(command)
         
-    def generate_alarm_page(self, navigation, entity, supported_features, alarmBtn):
+    def generate_alarm_page(self, navigation, entity, overwrite_supported_modes, alarmBtn):
         item = entity.entityId
         if not self._ha_api.entity_exists(item):
             command = f"entityUpd~{item}~{navigation}~Not found~Not found~Check your~Check your~apps.~apps.~yaml~yaml~0~~0"
@@ -462,18 +462,18 @@ class LuiPagesGen(object):
                 icon = get_icon_id("shield-off")
                 if not entity.attributes.get("code_arm_required", False):
                     numpad = "disable"
-                if supported_features is not None:
-                    bits = supported_features
-                else:
+                if overwrite_supported_modes is None:
                     bits = entity.attributes.supported_features
-                if bits & 0b000001:
-                    supported_modes.append("arm_home")
-                if bits & 0b000010:
-                    supported_modes.append("arm_away")
-                if bits & 0b000100:
-                    supported_modes.append("arm_night")
-                if bits & 0b100000:
-                    supported_modes.append("arm_vacation")
+                    if bits & 0b000001:
+                        supported_modes.append("arm_home")
+                    if bits & 0b000010:
+                        supported_modes.append("arm_away")
+                    if bits & 0b000100:
+                        supported_modes.append("arm_night")
+                    if bits & 0b100000:
+                        supported_modes.append("arm_vacation")
+                else:
+                    supported_modes = overwrite_supported_modes
             else:
                 supported_modes.append("disarm")
 
@@ -559,8 +559,8 @@ class LuiPagesGen(object):
             self.generate_media_page(navigation, card.title, card.entity, mediaBtn)
         if card.cardType == "cardAlarm":
             alarmBtn = card.raw_config.get("alarmControl")
-            supported_features = card.raw_config.get("supportedFeatures")
-            self.generate_alarm_page(navigation, card.entity, supported_features, alarmBtn)
+            overwrite_supported_modes = card.raw_config.get("supportedModes")
+            self.generate_alarm_page(navigation, card.entity, overwrite_supported_modes, alarmBtn)
         if card.cardType == "screensaver":
             theme = card.raw_config.get("theme")
             self.update_screensaver_weather(theme)

--- a/docs/card-alarm.md
+++ b/docs/card-alarm.md
@@ -18,3 +18,4 @@ key | optional | type | default | description
 `entity` | False | string | `None` | contains the entity of the current card
 `key` | True | string | `None` | Used by navigate items
 `alarmControl` | True | complex | `None` | overwrites the action executed on pressing the left bottom icon, by default this button is used to show a list of open sensors on a failed attempt to arm.
+`supportedModes` | True | list | `None` | Supply list of arm modes if you want to limit the modes on the card. Example `['arm_away', 'arm_night']`


### PR DESCRIPTION
Possibility to overwrite in config `supported_features` of an Alarm Control Panel to resolve #352

Example:
```
    cards:
      - type: cardAlarm
        title: Alarm Test 1
        entity: alarm_control_panel.alarmo
        supportedFeatures: 14
```