### PR TITLE
Alarm Panel icon color with status entity in cardGrid

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -192,7 +192,7 @@ class LuiPagesGen(object):
                 if item.status is not None and self._ha_api.entity_exists(item.status):
                     status_entity = self._ha_api.get_entity(item.status)
                     icon_res = get_icon_id_ha(item.status.split(".")[0], state=status_entity.state, device_class=status_entity.attributes.get("device_class", "_"), overwrite=icon)
-                    icon_color = self.get_entity_color(status_entity, overwrite=colorOverride)
+                    icon_color = self.get_entity_color(status_entity, ha_type=item.status.split(".")[0], overwrite=colorOverride)
                     if item.status.startswith("sensor") and cardType == "cardGrid":
                         icon_res = status_entity.state[:4]
                         if icon_res[-1] == ".":


### PR DESCRIPTION
Allow to have an Alarm Panel entity used with navigate and get the correct status color when passed as status in cardGrid. As an example:

```
    cards:
      - type: cardGrid
        title: Example
        entities:
          - entity: navigate.cardAlarm_myAlarm
            status: alarm_control_panel.my_alarm
            name: My Alarm
      - type: cardAlarm
        title: My Alarm
        entity: alarm_control_panel.my_alarm
        key: myAlarm
```