### PR TITLE
Change new line (\n) to add character return (\r\n)

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/controller.py
+++ b/apps/nspanel-lovelace-ui/luibackend/controller.py
@@ -357,6 +357,6 @@ class LuiController(object):
             entity = self._ha_api.get_entity(entity_id)
             if "open_sensors" in entity.attributes and entity.attributes.open_sensors is not None:
                 for e in entity.attributes.open_sensors:
-                    msg += f"- {self._ha_api.get_entity(e).attributes.friendly_name}\n"
+                    msg += f"- {self._ha_api.get_entity(e).attributes.friendly_name}\r\n"
             self._pages_gen.send_message_page("opnSensorNotifyRes", "", msg, "", "")
 


### PR DESCRIPTION
On the US Panel for English when multiple entities are open the control panel would put everything on one line instead of adding a new line between each entity, this fix changes that.  I don't know if this is an issue for other regions/languages