### PR TITLE
limit modes on cardThermo; implements #484

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -356,7 +356,7 @@ class LuiPagesGen(object):
             command += self.generate_entities_item(item, cardType)
         self._send_mqtt_msg(command)
 
-    def generate_thermo_page(self, navigation, title, entity, temp_unit):
+    def generate_thermo_page(self, navigation, title, entity, temp_unit, overwrite_supported_modes):
         item = entity.entityId
 
         if(temp_unit == "celsius"):
@@ -396,7 +396,8 @@ class LuiPagesGen(object):
             icon_res = ""
 
             hvac_modes = get_attr_safe(entity, "hvac_modes", [])
-
+            if overwrite_supported_modes is not None:
+                hvac_modes = overwrite_supported_modes
             for mode in hvac_modes:
                 icon_id = get_icon_id('alert-circle-outline')
                 color_on = 64512
@@ -596,7 +597,8 @@ class LuiPagesGen(object):
             return
         if card.cardType == "cardThermo":
             temp_unit = card.raw_config.get("temperatureUnit", "celsius")
-            self.generate_thermo_page(navigation, card.title, card.entity, temp_unit)
+            overwrite_supported_modes = card.raw_config.get("supportedModes")
+            self.generate_thermo_page(navigation, card.title, card.entity, temp_unit, overwrite_supported_modes)
         if card.cardType == "cardMedia":
             mediaBtn = card.raw_config.get("mediaControl", "")
             self.generate_media_page(navigation, card.title, card.entity, mediaBtn)

--- a/docs/card-climate.md
+++ b/docs/card-climate.md
@@ -24,3 +24,4 @@ key | optional | type | default | description
 `title` | True | string | `None` | Title of the Page 
 `temperatureUnit` | True | string | `celsius` | set this to fahrenheit to change the temperatureUnit on the page
 `key` | True | string | `None` | Used by navigate items in combination with the type (cardEntities_key)
+`supportedModes` | True | list | `None` | Supply list of heat actions if you want to limit the actions on the card. Example `['heat', 'off']`


### PR DESCRIPTION
Adds a option on cardThermo to limit the modes displayed.

```
      - type: cardThermo
        entity: climate.wohnzimmer_boden
        supportedModes: ["heat"]
```