### PR TITLE
Fix state / state_not logic error for entities

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -256,9 +256,9 @@ class LuiPagesGen(object):
         # HA Entities
         entity = apis.ha_api.get_entity(entityId)
         # check state for if a condition is defined
-        if item.condState is not None and item.condState == entity.state:
+        if item.condState is not None and item.condState != entity.state:
             return ""
-        if item.condStateNot is not None and item.condStateNot != entity.state:
+        if item.condStateNot is not None and item.condStateNot == entity.state:
             return ""
         
         # common res vars


### PR DESCRIPTION
According to the [documentation](https://docs.nspanel.pky.eu/entities/#possible-configuration-values-for-entities-key), an entity is only displayed
* if `state` is set: if the entity state is equal to the `state` value
* if `state_not` is set: if the entity state is not equal to the `state_not` value

So `""` – an **empty** string – shall only be returned – i.e. the **entity be hidden**
* if `state` is set: if the entity state is **not equal** to the `state` value
* if `state_not` is set: if the entity state is **equal** to the `state_not` value