### PR TITLE
Make single, right status icon possible on screensaver

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -190,6 +190,9 @@ class LuiPagesGen(object):
                 color = self.get_entity_color(entity, ha_type=entityType, overwrite=statusIcon.get("color", None))
                 status_res += f"~{icon}~{color}"
                 altfont += f'~{statusIcon.get("altFont", "")}'
+            else:
+                status_res += "~~"
+                altfont += "~"
 
         self._send_mqtt_msg(f"weatherUpdate~{icon_cur}~{text_cur}{weather_res}{altLayout}{status_res}{altfont}")        
         # send color if configured in screensaver


### PR DESCRIPTION
According to the [screensaver documentation](https://docs.nspanel.pky.eu/config-screensaver/), the `statusIcon2` option controls the status icon right of the date.

However, if only `statusIcon2` is configured, it would be drawn on the left side, instead of the right side.

This commit adds padding for status icons that are not configured.