### PR TITLE
Fix for empty detail page after change on previous page

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/controller.py
+++ b/apps/nspanel-lovelace-ui/luibackend/controller.py
@@ -180,17 +180,18 @@ class LuiController(object):
 
     def detail_open(self, detail_type, entity_id):
         if detail_type == "popupShutter":
-            self._pages_gen.generate_shutter_detail_page(entity_id)
+            self._pages_gen.generate_shutter_detail_page(entity_id, True)
         if detail_type == "popupLight":
-            self._pages_gen.generate_light_detail_page(entity_id)
+            self._pages_gen.generate_light_detail_page(entity_id, True)
         if detail_type == "popupFan":
-            self._pages_gen.generate_fan_detail_page(entity_id)
+            self._pages_gen.generate_fan_detail_page(entity_id, True)
         if detail_type == "popupThermo":
-            self._pages_gen.generate_thermo_detail_page(entity_id)
+            self._pages_gen.generate_thermo_detail_page(entity_id, True)
         if detail_type == "popupInSel":
-            self._pages_gen.generate_input_select_detail_page(entity_id)
+            self._pages_gen.generate_input_select_detail_page(entity_id, True)
         if detail_type == "popupTimer":
-            self._pages_gen.generate_timer_detail_page(entity_id)   
+            self._pages_gen.generate_timer_detail_page(entity_id, True)
+
     def button_press(self, entity_id, button_type, value):
         apis.ha_api.log(f"Button Press Event; entity_id: {entity_id}; button_type: {button_type}; value: {value} ")
         # internal buttons

--- a/apps/nspanel-lovelace-ui/luibackend/mqtt.py
+++ b/apps/nspanel-lovelace-ui/luibackend/mqtt.py
@@ -64,8 +64,9 @@ class LuiMqttSender(object):
         self._topic_send = topic_send
         self._prev_msg = ""
 
-    def send_mqtt_msg(self, msg, topic=None):
-        if self._prev_msg == msg:
+    def send_mqtt_msg(self, msg, topic=None, force=False):
+        if not force and self._prev_msg == msg:
+            self._ha_api.log(f"Dropping identical consecutive message: {msg}")
             return
         self._prev_msg = msg
         if topic is None:

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -709,7 +709,7 @@ class LuiPagesGen(object):
             self.generate_power_page(navigation, card.title, card.entities)
             return
 
-    def generate_light_detail_page(self, entity_id):
+    def generate_light_detail_page(self, entity_id, is_open_detail=False):
         entity = apis.ha_api.get_entity(entity_id)
         switch_val = 1 if entity.state == "on" else 0
         icon_color = self.get_entity_color(entity)
@@ -744,9 +744,9 @@ class LuiPagesGen(object):
         color_translation      = "Color"
         brightness_translation = get_translation(self._locale, "frontend.ui.card.light.brightness")
         color_temp_translation = get_translation(self._locale, "frontend.ui.card.light.color_temperature")
-        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~~{icon_color}~{switch_val}~{brightness}~{color_temp}~{color}~{color_translation}~{color_temp_translation}~{brightness_translation}~{effect_supported}")
+        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~~{icon_color}~{switch_val}~{brightness}~{color_temp}~{color}~{color_translation}~{color_temp_translation}~{brightness_translation}~{effect_supported}", force=is_open_detail)
     
-    def generate_shutter_detail_page(self, entity_id):
+    def generate_shutter_detail_page(self, entity_id, is_open_detail=False):
         entity       = apis.ha_api.get_entity(entity_id)
         entityType   = "cover"
         device_class = entity.attributes.get("device_class", "window")
@@ -812,9 +812,9 @@ class LuiPagesGen(object):
             if(tilt_pos == 100):
                 iconTiltLeftStatus  = "disable"
 
-        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~{pos}~{pos_translation}: {pos_status}~{pos_translation}~{icon_id}~{icon_up}~{icon_stop}~{icon_down}~{icon_up_status}~{icon_stop_status}~{icon_down_status}~{textTilt}~{iconTiltLeft}~{iconTiltStop}~{iconTiltRight}~{iconTiltLeftStatus}~{iconTiltStopStatus}~{iconTiltRightStatus}~{tilt_pos}")
+        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~{pos}~{pos_translation}: {pos_status}~{pos_translation}~{icon_id}~{icon_up}~{icon_stop}~{icon_down}~{icon_up_status}~{icon_stop_status}~{icon_down_status}~{textTilt}~{iconTiltLeft}~{iconTiltStop}~{iconTiltRight}~{iconTiltLeftStatus}~{iconTiltStopStatus}~{iconTiltRightStatus}~{tilt_pos}", force=is_open_detail)
 
-    def generate_fan_detail_page(self, entity_id):
+    def generate_fan_detail_page(self, entity_id, is_open_detail=False):
         entity = apis.ha_api.get_entity(entity_id)
         switch_val = 1 if entity.state == "on" else 0
         icon_color = self.get_entity_color(entity)
@@ -838,9 +838,9 @@ class LuiPagesGen(object):
         else:
             preset_modes = ""
 
-        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~~{icon_color}~{switch_val}~{speed}~{speedMax}~{speed_translation}~{preset_mode}~{preset_modes}")
+        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~~{icon_color}~{switch_val}~{speed}~{speedMax}~{speed_translation}~{preset_mode}~{preset_modes}", force=is_open_detail)
 
-    def generate_thermo_detail_page(self, entity_id):
+    def generate_thermo_detail_page(self, entity_id, is_open_detail=False):
         icon_id = get_icon_ha(entity_id)
         entity = apis.ha_api.get_entity(entity_id)
         icon_color = self.get_entity_color(entity, ha_type="climate")
@@ -862,9 +862,9 @@ class LuiPagesGen(object):
                 if modes:
                     modes_out += f"{heading}~{mode}~{cur_mode}~{modes_res}~"
 
-        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~{icon_id}~{icon_color}~{modes_out}")  
+        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~{icon_id}~{icon_color}~{modes_out}", force=is_open_detail)  
 
-    def generate_input_select_detail_page(self, entity_id):
+    def generate_input_select_detail_page(self, entity_id, is_open_detail=False):
         entity = apis.ha_api.get_entity(entity_id)
         options = []
         icon_color = 0
@@ -879,9 +879,9 @@ class LuiPagesGen(object):
             state = entity.attributes.get("source", "")
             options = entity.attributes.get("source_list", [])
         options = "?".join(options)
-        self._send_mqtt_msg(f"entityUpdateDetail2~{entity_id}~~{icon_color}~{ha_type}~{state}~{options}~")
+        self._send_mqtt_msg(f"entityUpdateDetail2~{entity_id}~~{icon_color}~{ha_type}~{state}~{options}~", force=is_open_detail)
 
-    def generate_timer_detail_page(self, entity_id):
+    def generate_timer_detail_page(self, entity_id, is_open_detail=False):
         if isinstance(entity_id, dict):
             entity_id = entity_id["entity_id"]
         entity = apis.ha_api.get_entity(entity_id)
@@ -915,7 +915,7 @@ class LuiPagesGen(object):
             label1  = get_translation(self._locale, "frontend.ui.card.timer.actions.pause")
             label2  = get_translation(self._locale, "frontend.ui.card.timer.actions.cancel")
             label3  = get_translation(self._locale, "frontend.ui.card.timer.actions.finish")
-        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~~{icon_color}~{entity_id}~{min_remaining}~{sec_remaining}~{editable}~{action1}~{action2}~{action3}~{label1}~{label2}~{label3}")
+        self._send_mqtt_msg(f"entityUpdateDetail~{entity_id}~~{icon_color}~{entity_id}~{min_remaining}~{sec_remaining}~{editable}~{action1}~{action2}~{action3}~{label1}~{label2}~{label3}", force=is_open_detail)
         
     def send_message_page(self, ident, heading, msg, b1, b2):
         self._send_mqtt_msg(f"pageType~popupNotify")


### PR DESCRIPTION
Currently identical consecutive MQTT messages are (silently) dropped. This causes a problem when a change occurs on an entity when that entity is on the active page and then the detail page for that entity is opened. The new state will be sent by state_change_callback when it occurs, and when detail_open is called after the detail is opened, the same message will be generated and drop. This pull request allows forcing sending MQTT messages and changes to let the generate_xx_detail_page functions know if it should force the message.