### PR TITLE
Enable to read YAxis Ticks from a datapoint in ioBroker

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -4695,15 +4695,17 @@ function GenerateChartPage(page: PageChart): Payload[] {
 
         let txt = getState(id + '.ACTUAL').val;
 
+        let yAxisTicks = (typeof page.items[0].yAxisTicks == 'object') ? page.items[0].yAxisTicks : JSON.parse(getState(page.items[0].yAxisTicks).val);
+
         out_msgs.push({
             payload:    'entityUpd~' +                              //entityUpd
                         heading + '~' +                             //heading
                         GetNavigationString(pageId) + '~' +         //navigation
                         rgb_dec565(page.items[0].onColor) + '~' +   //color
                         page.items[0].yAxis + '~' +
-                        page.items[0].yAxisTicks.join(':') + '~' +
+                        yAxisTicks.join(':') + '~' +
                         txt
-        });     
+        });
 
         if (Debug) console.log(out_msgs);
 
@@ -7362,7 +7364,7 @@ type PageItem = {
     setThermoAlias: (string[] | undefined),
     setThermoDestTemp2: (string | undefined),
     yAxis: (string | undefined),
-    yAxisTicks: (number[] | undefined),
+    yAxisTicks: (number[] | string | undefined),
     xAxisDecorationId: (string | undefined),
     popupType: (string | undefined),
     popupOptions: (string[] | undefined),

--- a/ioBroker/NsPanelTs_without_Examples.ts
+++ b/ioBroker/NsPanelTs_without_Examples.ts
@@ -4313,15 +4313,17 @@ function GenerateChartPage(page: PageChart): Payload[] {
 
         let txt = getState(id + '.ACTUAL').val;
 
+        let yAxisTicks = (typeof page.items[0].yAxisTicks == 'object') ? page.items[0].yAxisTicks : JSON.parse(getState(page.items[0].yAxisTicks).val);
+
         out_msgs.push({
             payload:    'entityUpd~' +                              //entityUpd
                         heading + '~' +                             //heading
                         GetNavigationString(pageId) + '~' +         //navigation
                         rgb_dec565(page.items[0].onColor) + '~' +   //color
                         page.items[0].yAxis + '~' +
-                        page.items[0].yAxisTicks.join(':') + '~' +
+                        yAxisTicks.join(':') + '~' +
                         txt
-        });     
+        });
 
         if (Debug) console.log(out_msgs);
 
@@ -6980,7 +6982,7 @@ type PageItem = {
     setThermoAlias: (string[] | undefined),
     setThermoDestTemp2: (string | undefined),
     yAxis: (string | undefined),
-    yAxisTicks: (number[] | undefined),
+    yAxisTicks: (number[] | string | undefined),
     xAxisDecorationId: (string | undefined),
     popupType: (string | undefined),
     popupOptions: (string[] | undefined),


### PR DESCRIPTION
Hi @Armilar 
with this change it would be possible to also use a Datapoint in ioBroker for yAxis Ticks in Charts.
The Datapoint should contain an Array identically to the current page configuration in the ioBroker Script.
As it's nicer to scale the Y Axis for e.g. outside temperature dynamically between summer and winter times this enables the user to include that in hin external script for the data generation and have more influence on the visualization.

Sorry, accidentially deleted the branch after i created the pull request the first time to the PR was changed to my main branch.