### PR TITLE
ioBroker - Make Screensaver IndicatorIcon Color for Bool invertable

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -7377,7 +7377,8 @@ function GetScreenSaverEntityColor(configElement: ScreenSaverElement | null): nu
         let colorReturn: any;
         if (configElement.ScreensaverEntityIconColor != undefined) {
             if (typeof getState(configElement.ScreensaverEntity).val == 'boolean') {
-                colorReturn = (getState(configElement.ScreensaverEntity).val == true) ? rgb_dec565(colorScale10) : rgb_dec565(colorScale0);
+                let iconvalbest = (configElement.ScreensaverEntityIconColor.val_best != undefined) ? configElement.ScreensaverEntityIconColor.val_best : false ;
+                colorReturn = (getState(configElement.ScreensaverEntity).val == iconvalbest) ? rgb_dec565(colorScale0) : rgb_dec565(colorScale10);
             } else if (typeof configElement.ScreensaverEntityIconColor == 'object') {
                 let iconvalmin = (configElement.ScreensaverEntityIconColor.val_min != undefined) ? configElement.ScreensaverEntityIconColor.val_min : 0 ;
                 let iconvalmax = (configElement.ScreensaverEntityIconColor.val_max != undefined) ? configElement.ScreensaverEntityIconColor.val_max : 100 ;

--- a/ioBroker/NsPanelTs_without_Examples.ts
+++ b/ioBroker/NsPanelTs_without_Examples.ts
@@ -6865,7 +6865,8 @@ function GetScreenSaverEntityColor(configElement: ScreenSaverElement | null): nu
         let colorReturn: any;
         if (configElement.ScreensaverEntityIconColor != undefined) {
             if (typeof getState(configElement.ScreensaverEntity).val == 'boolean') {
-                colorReturn = (getState(configElement.ScreensaverEntity).val == true) ? rgb_dec565(colorScale10) : rgb_dec565(colorScale0);
+                let iconvalbest = (configElement.ScreensaverEntityIconColor.val_best != undefined) ? configElement.ScreensaverEntityIconColor.val_best : false ;
+                colorReturn = (getState(configElement.ScreensaverEntity).val == iconvalbest) ? rgb_dec565(colorScale0) : rgb_dec565(colorScale10);
             } else if (typeof configElement.ScreensaverEntityIconColor == 'object') {
                 let iconvalmin = (configElement.ScreensaverEntityIconColor.val_min != undefined) ? configElement.ScreensaverEntityIconColor.val_min : 0 ;
                 let iconvalmax = (configElement.ScreensaverEntityIconColor.val_max != undefined) ? configElement.ScreensaverEntityIconColor.val_max : 100 ;


### PR DESCRIPTION
Hi @Armilar,

when a new IndicatorScreenSaverIcon points to a boolean value, it's automatically colored red or green.
But currently that's not invertable and not always is "false" the "good" value.

I've added some lines that "val_best" can now also be used to define if true or false should get colored green.
Default behavior if not set remains like it was before.

Greetings!