### PR TITLE
Fixed advanced screensaver boolean icon logic; improved code readability

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -6826,48 +6826,40 @@ function HandleScreensaverUpdate(): void {
                     if (config.leftScreensaverEntity[i] == null) {
                         checkpoint = false;
                         break;
-                    } else {
-                        RegisterScreensaverEntityWatcher(config.leftScreensaverEntity[i].ScreensaverEntity)
+                    }
+                    RegisterScreensaverEntityWatcher(config.leftScreensaverEntity[i].ScreensaverEntity)
+
+                    let val = getState(config.leftScreensaverEntity[i].ScreensaverEntity).val;
+                    let iconColor = rgb_dec565(White);
+                    let icon = Icons.GetIcon(config.leftScreensaverEntity[i].ScreensaverEntityIconOn);
+
+                    if (typeof(val) == 'number') {
+                        val = (val * config.leftScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.leftScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.leftScreensaverEntity[i].ScreensaverEntityUnitText;
+                        iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
+                    }
+                    else if (typeof(val) == 'boolean') {
+                        iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
+                        if (!val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
+                            icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
+                        }
+                    }
+                    else if (typeof(val) == 'string') {
+                        iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
+                        if (!isNaN(Date.parse(val))) {
+                            val = formatDate(getDateObject(val), config.leftScreensaverEntity[i].ScreensaverEntityDateFormat);
+                        }                
                     }
 
-                    if (checkpoint) {
-                        let val = getState(config.leftScreensaverEntity[i].ScreensaverEntity).val;
-                        let iconColor = rgb_dec565(White);
-                        let icon = Icons.GetIcon(config.leftScreensaverEntity[i].ScreensaverEntityIconOn);
-
-                        if (typeof(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val) == 'number') {
-                            val = (getState(config.leftScreensaverEntity[i].ScreensaverEntity).val * config.leftScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.leftScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.leftScreensaverEntity[i].ScreensaverEntityUnitText;
-                            iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
-                        }
-                        if (typeof(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val) == 'boolean') {
-                            val = (getState(config.leftScreensaverEntity[i].ScreensaverEntity).val);
-                            iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
-                            if (val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
-                                icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
-                            }
-                        }
-                        if (typeof getState(config.leftScreensaverEntity[i].ScreensaverEntity).val == 'string') {
-                            iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
-                            if (!isNaN(Date.parse(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val))) {
-                                val = formatDate(getDateObject(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val), config.leftScreensaverEntity[i].ScreensaverEntityDateFormat);
-                            } else {
-                                val = getState(config.leftScreensaverEntity[i].ScreensaverEntity).val;
-                            }                
-                        }
-
-                        if (existsObject(config.leftScreensaverEntity[i].ScreensaverEntityIconColor)) {
-                            iconColor = getState(config.leftScreensaverEntity[i].ScreensaverEntityIconColor).val;
-                        }
-
-                        payloadString += '~' +
-                                        '~' +
-                                        icon + '~' +
-                                        iconColor + '~' +
-                                        config.leftScreensaverEntity[i].ScreensaverEntityText + '~' +
-                                        val + '~';
-                    } else {
-                    console.log('Only ' + i+1 + ' leftScreensaverEntities defined');  
+                    if (existsObject(config.leftScreensaverEntity[i].ScreensaverEntityIconColor)) {
+                        iconColor = getState(config.leftScreensaverEntity[i].ScreensaverEntityIconColor).val;
                     }
+
+                    payloadString += '~' +
+                                    '~' +
+                                    icon + '~' +
+                                    iconColor + '~' +
+                                    config.leftScreensaverEntity[i].ScreensaverEntityText + '~' +
+                                    val + '~';
                 }
                 if (checkpoint == false) {
                     for (let j = i; j < 3; j++) {
@@ -6978,15 +6970,14 @@ function HandleScreensaverUpdate(): void {
                 if (getState(NSPanel_Path + 'Config.Screensaver.alternativeScreensaverLayout').val) {
                     let val = getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val;
                     let iconColor = rgb_dec565(White);
-                    if (typeof(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val) == 'number') {
-                        val = (getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val * config.bottomScreensaverEntity[4].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[4].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[4].ScreensaverEntityUnitText;
+                    if (typeof(val) == 'number') {
+                        val = (val * config.bottomScreensaverEntity[4].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[4].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[4].ScreensaverEntityUnitText;
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
                     }
-                    if (typeof(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val) == 'boolean') {
-                        val = (getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val);
+                    else if (typeof(val) == 'boolean') {
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
                     }
-                    if (typeof getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val == 'string') {
+                    else if (typeof(val) == 'string') {
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
                         if (!isNaN(Date.parse(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val))) {
                             val = formatDate(getDateObject(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val), config.bottomScreensaverEntity[4].ScreensaverEntityDateFormat);
@@ -7012,46 +7003,41 @@ function HandleScreensaverUpdate(): void {
                     if (config.bottomScreensaverEntity[i] == null) {
                         checkpoint = false;
                         break;
-                    } else {
-                        RegisterScreensaverEntityWatcher(config.bottomScreensaverEntity[i].ScreensaverEntity)
-                    }
-                    if (checkpoint) {
-                        let val = getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val;
-                        let iconColor = rgb_dec565(White);
-                        let icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOn);
+                    } 
+                    RegisterScreensaverEntityWatcher(config.bottomScreensaverEntity[i].ScreensaverEntity)
+                    
+                    let val = getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val;
+                    let iconColor = rgb_dec565(White);
+                    let icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOn);
 
-                        if (typeof(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val) == 'number') {
-                            val = (getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val * config.bottomScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[i].ScreensaverEntityUnitText;
-                            iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
-                        }
-                        if (typeof(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val) == 'boolean') {
-                            val = (getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val);
-                            iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
-                            if (val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
-                                icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
-                            }
-                        }
-                        if (typeof getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val == 'string') {
-                            iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
-                            if (!isNaN(Date.parse(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val))) {
-                                val = formatDate(getDateObject(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val), config.bottomScreensaverEntity[i].ScreensaverEntityDateFormat);
-                            } else {
-                                val = getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val;
-                            }                
-                        }
-                        if (existsObject(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor)) {
-                            iconColor = getState(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor).val;
-                        }
-                        if (i < maxEntities - 1) {
-                            val = val + '~';
-                        }
-                        payloadString += '~' +
-                                        '~' +
-                                        icon + '~' +
-                                        iconColor + '~' +
-                                        config.bottomScreensaverEntity[i].ScreensaverEntityText + '~' +
-                                        val
+                    if (typeof(val) == 'number') {
+                        val = (val * config.bottomScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[i].ScreensaverEntityUnitText;
+                        iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
                     }
+                    else if (typeof(val) == 'boolean') {
+                        iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
+                        if (!val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
+                            icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
+                        }
+                    }
+                    else if (typeof(val) == 'string') {
+                        iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
+                        if (!isNaN(Date.parse(val))) {
+                            val = formatDate(getDateObject(val), config.bottomScreensaverEntity[i].ScreensaverEntityDateFormat);
+                        }                
+                    }
+                    if (existsObject(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor)) {
+                        iconColor = getState(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor).val;
+                    }
+                    if (i < maxEntities - 1) {
+                        val = val + '~';
+                    }
+                    payloadString += '~' +
+                                    '~' +
+                                    icon + '~' +
+                                    iconColor + '~' +
+                                    config.bottomScreensaverEntity[i].ScreensaverEntityText + '~' +
+                                    val
                 }
                 if (checkpoint == false) {
                     for (let j = i; j < maxEntities - 1; j++) {
@@ -7067,43 +7053,39 @@ function HandleScreensaverUpdate(): void {
                     if (config.indicatorScreensaverEntity[i] == null) {
                         checkpoint = false;
                         break;
+                    }
+                    RegisterScreensaverEntityWatcher(config.indicatorScreensaverEntity[i].ScreensaverEntity)
+
+                    let val = getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val;
+                    let iconColor = rgb_dec565(White);
+            
+                    let icon = null;
+                    if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn)) {
+                        let iconName = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn).val;
+                        icon = Icons.GetIcon(iconName);
                     } else {
-                        RegisterScreensaverEntityWatcher(config.indicatorScreensaverEntity[i].ScreensaverEntity)
-                    }
+                        icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn);
+                    }    
 
-                    if (checkpoint) {
-                        let val = getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val;
-                        let iconColor = rgb_dec565(White);
-			    
-			let icon = null;
-                        if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn)) {
-                            let iconName = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn).val;
-                            icon = Icons.GetIcon(iconName);
-                        } else {
-                            icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn);
-                        }    
-
-                        if (typeof(getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val) == 'number') {
-                            val = (getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val * config.indicatorScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.indicatorScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.indicatorScreensaverEntity[i].ScreensaverEntityUnitText;
-                            iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
-                        }
-                        if (typeof(getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val) == 'boolean') {
-                            val = (getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val);
-                            iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
-                            if (val && config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff != null) {
-                                icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff)
-                            }
-                        }
-                        if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor)) {
-                            iconColor = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor).val;
-                        }
-                        payloadString += '~' +
-                                        '~' +
-                                        icon + '~' +
-                                        iconColor + '~' +
-                                        config.indicatorScreensaverEntity[i].ScreensaverEntityText + '~' +
-                                        val + '~';
+                    if (typeof(val) == 'number') {
+                        val = (val * config.indicatorScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.indicatorScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.indicatorScreensaverEntity[i].ScreensaverEntityUnitText;
+                        iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
                     }
+                    else if (typeof(val) == 'boolean') {
+                        iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
+                        if (!val && config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff != null) {
+                            icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff)
+                        }
+                    }
+                    if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor)) {
+                        iconColor = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor).val;
+                    }
+                    payloadString += '~' +
+                                    '~' +
+                                    icon + '~' +
+                                    iconColor + '~' +
+                                    config.indicatorScreensaverEntity[i].ScreensaverEntityText + '~' +
+                                    val + '~';
                 }
             }
             if (Debug) console.log('weatherUpdate~' + payloadString);

--- a/ioBroker/NsPanelTs_without_Examples.ts
+++ b/ioBroker/NsPanelTs_without_Examples.ts
@@ -6314,48 +6314,40 @@ function HandleScreensaverUpdate(): void {
                     if (config.leftScreensaverEntity[i] == null) {
                         checkpoint = false;
                         break;
-                    } else {
-                        RegisterScreensaverEntityWatcher(config.leftScreensaverEntity[i].ScreensaverEntity)
+                    }
+                    RegisterScreensaverEntityWatcher(config.leftScreensaverEntity[i].ScreensaverEntity)
+
+                    let val = getState(config.leftScreensaverEntity[i].ScreensaverEntity).val;
+                    let iconColor = rgb_dec565(White);
+                    let icon = Icons.GetIcon(config.leftScreensaverEntity[i].ScreensaverEntityIconOn);
+
+                    if (typeof(val) == 'number') {
+                        val = (val * config.leftScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.leftScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.leftScreensaverEntity[i].ScreensaverEntityUnitText;
+                        iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
+                    }
+                    else if (typeof(val) == 'boolean') {
+                        iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
+                        if (!val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
+                            icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
+                        }
+                    }
+                    else if (typeof(val) == 'string') {
+                        iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
+                        if (!isNaN(Date.parse(val))) {
+                            val = formatDate(getDateObject(val), config.leftScreensaverEntity[i].ScreensaverEntityDateFormat);
+                        }                
                     }
 
-                    if (checkpoint) {
-                        let val = getState(config.leftScreensaverEntity[i].ScreensaverEntity).val;
-                        let iconColor = rgb_dec565(White);
-                        let icon = Icons.GetIcon(config.leftScreensaverEntity[i].ScreensaverEntityIconOn);
-
-                        if (typeof(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val) == 'number') {
-                            val = (getState(config.leftScreensaverEntity[i].ScreensaverEntity).val * config.leftScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.leftScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.leftScreensaverEntity[i].ScreensaverEntityUnitText;
-                            iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
-                        }
-                        if (typeof(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val) == 'boolean') {
-                            val = (getState(config.leftScreensaverEntity[i].ScreensaverEntity).val);
-                            iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
-                            if (val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
-                                icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
-                            }
-                        }
-                        if (typeof getState(config.leftScreensaverEntity[i].ScreensaverEntity).val == 'string') {
-                            iconColor = GetScreenSaverEntityColor(config.leftScreensaverEntity[i]);
-                            if (!isNaN(Date.parse(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val))) {
-                                val = formatDate(getDateObject(getState(config.leftScreensaverEntity[i].ScreensaverEntity).val), config.leftScreensaverEntity[i].ScreensaverEntityDateFormat);
-                            } else {
-                                val = getState(config.leftScreensaverEntity[i].ScreensaverEntity).val;
-                            }                
-                        }
-
-                        if (existsObject(config.leftScreensaverEntity[i].ScreensaverEntityIconColor)) {
-                            iconColor = getState(config.leftScreensaverEntity[i].ScreensaverEntityIconColor).val;
-                        }
-
-                        payloadString += '~' +
-                                        '~' +
-                                        icon + '~' +
-                                        iconColor + '~' +
-                                        config.leftScreensaverEntity[i].ScreensaverEntityText + '~' +
-                                        val + '~';
-                    } else {
-                    console.log('Only ' + i+1 + ' leftScreensaverEntities defined');  
+                    if (existsObject(config.leftScreensaverEntity[i].ScreensaverEntityIconColor)) {
+                        iconColor = getState(config.leftScreensaverEntity[i].ScreensaverEntityIconColor).val;
                     }
+
+                    payloadString += '~' +
+                                    '~' +
+                                    icon + '~' +
+                                    iconColor + '~' +
+                                    config.leftScreensaverEntity[i].ScreensaverEntityText + '~' +
+                                    val + '~';
                 }
                 if (checkpoint == false) {
                     for (let j = i; j < 3; j++) {
@@ -6466,15 +6458,14 @@ function HandleScreensaverUpdate(): void {
                 if (getState(NSPanel_Path + 'Config.Screensaver.alternativeScreensaverLayout').val) {
                     let val = getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val;
                     let iconColor = rgb_dec565(White);
-                    if (typeof(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val) == 'number') {
-                        val = (getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val * config.bottomScreensaverEntity[4].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[4].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[4].ScreensaverEntityUnitText;
+                    if (typeof(val) == 'number') {
+                        val = (val * config.bottomScreensaverEntity[4].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[4].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[4].ScreensaverEntityUnitText;
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
                     }
-                    if (typeof(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val) == 'boolean') {
-                        val = (getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val);
+                    else if (typeof(val) == 'boolean') {
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
                     }
-                    if (typeof getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val == 'string') {
+                    else if (typeof(val) == 'string') {
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
                         if (!isNaN(Date.parse(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val))) {
                             val = formatDate(getDateObject(getState(config.bottomScreensaverEntity[4].ScreensaverEntity).val), config.bottomScreensaverEntity[4].ScreensaverEntityDateFormat);
@@ -6500,46 +6491,41 @@ function HandleScreensaverUpdate(): void {
                     if (config.bottomScreensaverEntity[i] == null) {
                         checkpoint = false;
                         break;
-                    } else {
-                        RegisterScreensaverEntityWatcher(config.bottomScreensaverEntity[i].ScreensaverEntity)
-                    }
-                    if (checkpoint) {
-                        let val = getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val;
-                        let iconColor = rgb_dec565(White);
-                        let icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOn);
+                    } 
+                    RegisterScreensaverEntityWatcher(config.bottomScreensaverEntity[i].ScreensaverEntity)
+                    
+                    let val = getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val;
+                    let iconColor = rgb_dec565(White);
+                    let icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOn);
 
-                        if (typeof(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val) == 'number') {
-                            val = (getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val * config.bottomScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[i].ScreensaverEntityUnitText;
-                            iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
-                        }
-                        if (typeof(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val) == 'boolean') {
-                            val = (getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val);
-                            iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
-                            if (val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
-                                icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
-                            }
-                        }
-                        if (typeof getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val == 'string') {
-                            iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
-                            if (!isNaN(Date.parse(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val))) {
-                                val = formatDate(getDateObject(getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val), config.bottomScreensaverEntity[i].ScreensaverEntityDateFormat);
-                            } else {
-                                val = getState(config.bottomScreensaverEntity[i].ScreensaverEntity).val;
-                            }                
-                        }
-                        if (existsObject(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor)) {
-                            iconColor = getState(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor).val;
-                        }
-                        if (i < maxEntities - 1) {
-                            val = val + '~';
-                        }
-                        payloadString += '~' +
-                                        '~' +
-                                        icon + '~' +
-                                        iconColor + '~' +
-                                        config.bottomScreensaverEntity[i].ScreensaverEntityText + '~' +
-                                        val
+                    if (typeof(val) == 'number') {
+                        val = (val * config.bottomScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.bottomScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.bottomScreensaverEntity[i].ScreensaverEntityUnitText;
+                        iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
                     }
+                    else if (typeof(val) == 'boolean') {
+                        iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
+                        if (!val && config.bottomScreensaverEntity[i].ScreensaverEntityIconOff != null) {
+                            icon = Icons.GetIcon(config.bottomScreensaverEntity[i].ScreensaverEntityIconOff)
+                        }
+                    }
+                    else if (typeof(val) == 'string') {
+                        iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[i]);
+                        if (!isNaN(Date.parse(val))) {
+                            val = formatDate(getDateObject(val), config.bottomScreensaverEntity[i].ScreensaverEntityDateFormat);
+                        }                
+                    }
+                    if (existsObject(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor)) {
+                        iconColor = getState(config.bottomScreensaverEntity[i].ScreensaverEntityIconColor).val;
+                    }
+                    if (i < maxEntities - 1) {
+                        val = val + '~';
+                    }
+                    payloadString += '~' +
+                                    '~' +
+                                    icon + '~' +
+                                    iconColor + '~' +
+                                    config.bottomScreensaverEntity[i].ScreensaverEntityText + '~' +
+                                    val
                 }
                 if (checkpoint == false) {
                     for (let j = i; j < maxEntities - 1; j++) {
@@ -6555,43 +6541,39 @@ function HandleScreensaverUpdate(): void {
                     if (config.indicatorScreensaverEntity[i] == null) {
                         checkpoint = false;
                         break;
+                    }
+                    RegisterScreensaverEntityWatcher(config.indicatorScreensaverEntity[i].ScreensaverEntity)
+
+                    let val = getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val;
+                    let iconColor = rgb_dec565(White);
+            
+                    let icon = null;
+                    if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn)) {
+                        let iconName = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn).val;
+                        icon = Icons.GetIcon(iconName);
                     } else {
-                        RegisterScreensaverEntityWatcher(config.indicatorScreensaverEntity[i].ScreensaverEntity)
-                    }
+                        icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn);
+                    }    
 
-                    if (checkpoint) {
-                        let val = getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val;
-                        let iconColor = rgb_dec565(White);
-			    
-			let icon = null;
-                        if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn)) {
-                            let iconName = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn).val;
-                            icon = Icons.GetIcon(iconName);
-                        } else {
-                            icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOn);
-                        }    
-
-                        if (typeof(getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val) == 'number') {
-                            val = (getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val * config.indicatorScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.indicatorScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.indicatorScreensaverEntity[i].ScreensaverEntityUnitText;
-                            iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
-                        }
-                        if (typeof(getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val) == 'boolean') {
-                            val = (getState(config.indicatorScreensaverEntity[i].ScreensaverEntity).val);
-                            iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
-                            if (val && config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff != null) {
-                                icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff)
-                            }
-                        }
-                        if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor)) {
-                            iconColor = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor).val;
-                        }
-                        payloadString += '~' +
-                                        '~' +
-                                        icon + '~' +
-                                        iconColor + '~' +
-                                        config.indicatorScreensaverEntity[i].ScreensaverEntityText + '~' +
-                                        val + '~';
+                    if (typeof(val) == 'number') {
+                        val = (val * config.indicatorScreensaverEntity[i].ScreensaverEntityFactor).toFixed(config.indicatorScreensaverEntity[i].ScreensaverEntityDecimalPlaces) + config.indicatorScreensaverEntity[i].ScreensaverEntityUnitText;
+                        iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
                     }
+                    else if (typeof(val) == 'boolean') {
+                        iconColor = GetScreenSaverEntityColor(config.indicatorScreensaverEntity[i]);
+                        if (!val && config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff != null) {
+                            icon = Icons.GetIcon(config.indicatorScreensaverEntity[i].ScreensaverEntityIconOff)
+                        }
+                    }
+                    if (existsObject(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor)) {
+                        iconColor = getState(config.indicatorScreensaverEntity[i].ScreensaverEntityIconColor).val;
+                    }
+                    payloadString += '~' +
+                                    '~' +
+                                    icon + '~' +
+                                    iconColor + '~' +
+                                    config.indicatorScreensaverEntity[i].ScreensaverEntityText + '~' +
+                                    val + '~';
                 }
             }
             if (Debug) console.log('weatherUpdate~' + payloadString);


### PR DESCRIPTION
When using the new "advanced screensaver" mode I've found that boolean values are using the wrong icon.
When the boolean value is true, then the ScreensaverEntityIconOff is used and when it's false, the ScreensaverEntityIconOn is used.
I think this is false and I would like to suggest to switch them.
This PR provides the the change. I've also improved the readability of the code in HandleScreensaverUpdate().
I saw the PR #799 of @bembelstemmer. That one is about the color of the icon.
My suggestion is about the icon itself. I think the "Off"-Icon (ScreensaverEntityIconOff) should be used for a false state and the "On"-Icon for true state.
I've also made the HandleScreensaverUpdate function a little bit better readable by using variable instead of multiple getting the same datapoints
This is a duplicate of another PR #806 which I have deleted because of some commits that I didn't want to be part of the PR. Sorry for the confusion.