### PR TITLE
Improve and fix docker appdaemon

### DIFF
--- a/docs/prepare_ha.md
+++ b/docs/prepare_ha.md
@@ -34,10 +34,14 @@ services:
 	
   appdaemon:
     container_name: appdaemon
-    image: acockburn/appdaemon:latest
+    image: acockburn/appdaemon:4.2.3
     environment:
       - HA_URL=http://your-homeassistant-url:8123
       - TOKEN="xxxxxx"
+      - DASH_URL=http://localhost:5050
+      - TZ=Europe/Berlin
+    ports:
+      - 5050:5050
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ./docker-data/homeassistant/appdaemon:/conf

--- a/docs/prepare_ha.md
+++ b/docs/prepare_ha.md
@@ -38,10 +38,6 @@ services:
     environment:
       - HA_URL=http://your-homeassistant-url:8123
       - TOKEN="xxxxxx"
-      - DASH_URL=http://localhost:5050
-      - TZ=Europe/Berlin
-    ports:
-      - 5050:5050
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ./docker-data/homeassistant/appdaemon:/conf


### PR DESCRIPTION
- Hardcode the 4.2.3 tag version meanwhile latest version (4.4.0) is stable and working with nspanel (https://github.com/joBr99/nspanel-lovelace-ui/issues/847)
- Add Dashboard url for the webui of appdaemon on default appdaemon port 5050
- Add Timezone like in HA 

