### PR TITLE
Fix: Remove empty log statements

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------
-TypeScript v4.0.5.13 zur Steuerung des SONOFF NSPanel mit dem ioBroker by @Armilar / @Sternmiere / @Britzelpuf / @ravenS0ne / @TT-Tom
+TypeScript v4.0.5.14 zur Steuerung des SONOFF NSPanel mit dem ioBroker by @Armilar / @Sternmiere / @Britzelpuf / @ravenS0ne / @TT-Tom
 - abgestimmt auf TFT 50 / v4.0.5 / BerryDriver 8 / Tasmota 12.5.0
 @joBr99 Projekt: https://github.com/joBr99/nspanel-lovelace-ui/tree/main/ioBroker
 NsPanelTs.ts (dieses TypeScript in ioBroker) Stable: https://github.com/joBr99/nspanel-lovelace-ui/blob/main/ioBroker/NsPanelTs.ts
@@ -137,6 +137,7 @@ ReleaseNotes:
         - 28.04.2023 - v4.0.5.11 light 'hue' and light 'rgb' have '.TEMPERATURE' optional
         - 02.05.2023 - v4.0.5.12 Add new Function Debug mode from script activatable via panel
 	- 02.05.2023 - v4.0.5.13 Fix Problems with weather-instances-number !="0" #876
+	- 02.05.2023 - v4.0.5.14 Fix: Remove empty log statements #883
 	
 ***********************************************************************************************************
 * Für die Erstellung der Aliase durch das Skript, muss in der JavaScript Instanz "setObect" gesetzt sein! *

--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -7373,7 +7373,6 @@ function HandleScreensaverStatusIcons() : void {
                     }
                 } 
                 if (config.mrIcon2ScreensaverEntity.ScreensaverEntityValue != null) {
-                    console.log()
                     if (isNaN(getState(config.mrIcon2ScreensaverEntity.ScreensaverEntityValue).val) == false) {
                         payloadString += (getState(config.mrIcon2ScreensaverEntity.ScreensaverEntityValue).val).toFixed(config.mrIcon2ScreensaverEntity.ScreensaverEntityValueDecimalPlace);
                         payloadString += (config.mrIcon2ScreensaverEntity.ScreensaverEntityValueUnit == null) ? '' : config.mrIcon2ScreensaverEntity.ScreensaverEntityValueUnit;

--- a/ioBroker/NsPanelTs_without_Examples.ts
+++ b/ioBroker/NsPanelTs_without_Examples.ts
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------
-TypeScript v4.0.5.13 zur Steuerung des SONOFF NSPanel mit dem ioBroker by @Armilar / @Sternmiere / @Britzelpuf / @ravenS0ne / @TT-Tom
+TypeScript v4.0.5.14 zur Steuerung des SONOFF NSPanel mit dem ioBroker by @Armilar / @Sternmiere / @Britzelpuf / @ravenS0ne / @TT-Tom
 - abgestimmt auf TFT 50 / v4.0.5 / BerryDriver 8 / Tasmota 12.5.0
 @joBr99 Projekt: https://github.com/joBr99/nspanel-lovelace-ui/tree/main/ioBroker
 NsPanelTs.ts (dieses TypeScript in ioBroker) Stable: https://github.com/joBr99/nspanel-lovelace-ui/blob/main/ioBroker/NsPanelTs.ts
@@ -137,6 +137,7 @@ ReleaseNotes:
         - 28.04.2023 - v4.0.5.11 light 'hue' and light 'rgb' have '.TEMPERATURE' optional
         - 02.05.2023 - v4.0.5.12 Add new Function Debug mode from script activatable via panel
 	- 02.05.2023 - v4.0.5.13 Fix Problems with weather-instances-number !="0" #876
+	- 02.05.2023 - v4.0.5.14 Fix: Remove empty log statements (PR #883)
 	
 ***********************************************************************************************************
 * Für die Erstellung der Aliase durch das Skript, muss in der JavaScript Instanz "setObect" gesetzt sein! *

--- a/ioBroker/NsPanelTs_without_Examples.ts
+++ b/ioBroker/NsPanelTs_without_Examples.ts
@@ -6874,7 +6874,6 @@ function HandleScreensaverStatusIcons() : void {
                     }
                 } 
                 if (config.mrIcon2ScreensaverEntity.ScreensaverEntityValue != null) {
-                    console.log()
                     if (isNaN(getState(config.mrIcon2ScreensaverEntity.ScreensaverEntityValue).val) == false) {
                         payloadString += (getState(config.mrIcon2ScreensaverEntity.ScreensaverEntityValue).val).toFixed(config.mrIcon2ScreensaverEntity.ScreensaverEntityValueDecimalPlace);
                         payloadString += (config.mrIcon2ScreensaverEntity.ScreensaverEntityValueUnit == null) ? '' : config.mrIcon2ScreensaverEntity.ScreensaverEntityValueUnit;


### PR DESCRIPTION
Hi @Armilar
a short fix to remove unneccessary logs with message "undefined" on every screensaver update