### PR TITLE
Fix cover tilt setting in AppDaemon backend

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/controller.py
+++ b/apps/nspanel-lovelace-ui/luibackend/controller.py
@@ -275,7 +275,7 @@ class LuiController(object):
             apis.ha_api.get_entity(entity_id).call_service("close_cover_tilt")
         if button_type == "tiltSlider":
             pos = int(value)
-            apis.ha_api.get_entity(entity_id).call_service("set_cover_tilt_position", position=pos)
+            apis.ha_api.get_entity(entity_id).call_service("set_cover_tilt_position", tilt_position=pos)
 
 
         if button_type == "button":


### PR DESCRIPTION
Argument sent to `set_cover_tilt_position` is wrong, so HA returns error 400 when trying to set the tilt. This PR fixes it by using the correct argument per [HA docs](https://www.home-assistant.io/integrations/cover/#service-coverset_cover_tilt_position).