### PR TITLE
add optional timezone parameters on screensaver

### DIFF
--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -68,6 +68,8 @@ key | optional | type | default | description
 `dateAdditionalTemplate` | True | string | `""` | Addional Text dispayed after Date, can contain a Homeassistant Template Example `" - {{ states('sun.sun') }}"`
 `timeAdditionalTemplate` | True | string | `""` | Addional Text dispayed below Time, can contain a Homeassistant Template
 `dateFormat` | True | string | `%A, %d. %B %Y` | date format used if babel is not installed
+`timeTzOrig` | True | string | "" | Timezone of the App Daemon server, like `UTC`
+`timeTzDest` | True | string | "" | Timezone of the NSPanel, like `CEST`
 `defaultBackgroundColor` | True | string | ha-dark | backgroud color of all cards, valid values: `black`, `ha-dark`
 `cards` | False | complex | | configuration for cards that are displayed on panel; see docs for cards
 `screensaver` | True | complex | | configuration for screensaver; see docs for screensaver


### PR DESCRIPTION
Hi!

I'd like to submit this PR which allow setting different timezone for the AppDaemon and the NSPanel.
The goal is to support setups where the AppDaemon is running on some servers, let's say, configured in `UTC` and NSPanel on some other timezone, like `CET`.

This PR introduce two new settings: `timeTzOrig` (for the AppDaemon) and `timeTzDest` (for the NSPanel).
These two new settings are usable through the `OBJ->config` parent, like the remaining of date configuration.

This PR does not change the actual behavior of the `update_time` method.
But, when one of the two new parameters (or both) are set, it reflects the timezone difference onto the displayed time.

Thank you!