### PR TITLE
add optional timezone parameter on screensaver time

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -1,4 +1,5 @@
 import datetime
+from dateutil import tz
 import dateutil.parser as dp
 import time
 
@@ -108,10 +109,17 @@ class LuiPagesGen(object):
 
 
     def update_time(self, kwargs):
-        time = datetime.datetime.now().strftime(self._config.get("timeFormat"))
+        time = None
+        # get current time, with timezone if set
+        if self._config.get("timeTz"):
+            timezone = tz.gettz(self._config.get("timeTz"))
+            time = datetime.datetime.now(tz=timezone)
+        else:
+            time = datetime.datetime.now()
+        nice_time = time.strftime(self._config.get("timeFormat"))
         addTemplate = self._config.get("timeAdditionalTemplate")
         addTimeText = apis.ha_api.render_template(addTemplate)
-        self._send_mqtt_msg(f"time~{time}~{addTimeText}")
+        self._send_mqtt_msg(f"time~{nice_time}~{addTimeText}")
 
     def update_date(self, kwargs):
         global babel_spec

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -111,8 +111,8 @@ class LuiPagesGen(object):
     def update_time(self, kwargs):
         time = None
         # get current time, with timezone if set
-        if self._config.get("timeTz"):
-            timezone = tz.gettz(self._config.get("timeTz"))
+        if self._config.get("timezone"):
+            timezone = tz.gettz(self._config.get("timezone"))
             time = datetime.datetime.now(tz=timezone)
         else:
             time = datetime.datetime.now()

--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -68,7 +68,7 @@ key | optional | type | default | description
 `dateAdditionalTemplate` | True | string | `""` | Addional Text dispayed after Date, can contain a Homeassistant Template Example `" - {{ states('sun.sun') }}"`
 `timeAdditionalTemplate` | True | string | `""` | Addional Text dispayed below Time, can contain a Homeassistant Template
 `dateFormat` | True | string | `%A, %d. %B %Y` | date format used if babel is not installed
-`timezone` | True | string | "" | Timezone for the time on the panel: `Europe/Berlin` - See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of TZ Identifiers
+`timezone` | True | string | "" | Timezone for the time on the panel: `Europe/Berlin` - See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of TZ Identifiers (supported from upcoming version v4.4)
 `defaultBackgroundColor` | True | string | ha-dark | backgroud color of all cards, valid values: `black`, `ha-dark`
 `cards` | False | complex | | configuration for cards that are displayed on panel; see docs for cards
 `screensaver` | True | complex | | configuration for screensaver; see docs for screensaver

--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -68,7 +68,7 @@ key | optional | type | default | description
 `dateAdditionalTemplate` | True | string | `""` | Addional Text dispayed after Date, can contain a Homeassistant Template Example `" - {{ states('sun.sun') }}"`
 `timeAdditionalTemplate` | True | string | `""` | Addional Text dispayed below Time, can contain a Homeassistant Template
 `dateFormat` | True | string | `%A, %d. %B %Y` | date format used if babel is not installed
-`timeTz` | True | string | "" | Timezone to set on date of the NSPanel, like `CET`
+`timezone` | True | string | "" | Timezone for the time on the panel: `Europe/Berlin` - See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of TZ Identifiers
 `defaultBackgroundColor` | True | string | ha-dark | backgroud color of all cards, valid values: `black`, `ha-dark`
 `cards` | False | complex | | configuration for cards that are displayed on panel; see docs for cards
 `screensaver` | True | complex | | configuration for screensaver; see docs for screensaver

--- a/docs/config-overview.md
+++ b/docs/config-overview.md
@@ -68,6 +68,7 @@ key | optional | type | default | description
 `dateAdditionalTemplate` | True | string | `""` | Addional Text dispayed after Date, can contain a Homeassistant Template Example `" - {{ states('sun.sun') }}"`
 `timeAdditionalTemplate` | True | string | `""` | Addional Text dispayed below Time, can contain a Homeassistant Template
 `dateFormat` | True | string | `%A, %d. %B %Y` | date format used if babel is not installed
+`timeTz` | True | string | "" | Timezone to set on date of the NSPanel, like `CET`
 `defaultBackgroundColor` | True | string | ha-dark | backgroud color of all cards, valid values: `black`, `ha-dark`
 `cards` | False | complex | | configuration for cards that are displayed on panel; see docs for cards
 `screensaver` | True | complex | | configuration for screensaver; see docs for screensaver


### PR DESCRIPTION
Hi!

I'd like to submit this PR which allow setting different timezone for the time displayed on the NSPanel.
The goal is to support setups where the AppDaemon is running on some servers, let's say, configured in UTC and NSPanel on some other timezone, like CET.

This PR introduce a new setting: `timeTz`.
This setting is usable through the OBJ->config parent, like the remaining of date configuration.

This PR does not change the actual behavior of the update_time method.
But, when the new parameter is set, it reflects the timezone onto the displayed time.

Thank you!

NB: This is the following of the issue #1019 