### PR TITLE
feat: calculate yAxisTicks based on given values

### DIFF
--- a/ioBroker/DEV/NSPanelTs.ts
+++ b/ioBroker/DEV/NSPanelTs.ts
@@ -6177,7 +6177,7 @@ function GenerateChartPage(page: NSPanel.PageChart): NSPanel.Payload[] {
             }            
 
             if (Debug) {
-                log(`Calculated yAxisTicks for ${id} (Min: ${minValue}, Max: ${maxValue}, Tick: ${tick}): ${page.items[0].yAxisTicks}`);
+                log(`Calculated yAxisTicks for ${id} (Min: ${minValue}, Max: ${maxValue}, Tick: ${tick}): ${yAxisTicks}`);
             }
         } else {            
             yAxisTicks = typeof page.items[0].yAxisTicks === 'string'


### PR DESCRIPTION
IMHO the `yAxisTicks` parameter for `chartPage` is a little bit hard to understand, given the required formatting. Besides that, in the example the `yAxisTicks` for the office temperature are from -25° to +25° C which makes no sense, at least for me.
But there is really no need to provide them at all because we can caluclate the yAxisTicks based on the provided values. In this pull request there is an added algorithm which calculates the ticks if no `yAxisTicks` was provided for the page. This makes configuring the `chartPage` a little bit easier and more responsive.

Example debug logging:
```
Calculated yAxisTicks for 0_userdata.0....Temperature (Min: 186, Max: 214, Tick: 10): 176,186,196,206,216
Calculated yAxisTicks for 0_userdata.0....Humidity (Min: 650, Max: 729, Tick: 16): 634,650,666,682,698,714,730
Calculated yAxisTicks for 0_userdata.0....Speedtest.Download (Min: 137, Max: 581, Tick: 89): 48,137,226,315,404,493,582
```
Notice how the amount of calculated ticks changes with the given range of values to display.

![image](https://github.com/joBr99/nspanel-lovelace-ui/assets/6503243/9ae84129-7ca5-49d8-adb0-5d9b14d3765d)