### PR TITLE
feat: write button event to states

### DIFF
--- a/ioBroker/DEV/NSPanelTs.ts
+++ b/ioBroker/DEV/NSPanelTs.ts
@@ -6312,6 +6312,10 @@ function HandleButtonEvent(words: any): void {
             alwaysOn = false;
             SendToPanel({ payload: 'timeout~' + getState(NSPanel_Path + 'Config.Screensaver.timeoutScreensaver').val });
         }
+	
+        setOrCreate(NSPanel_Path + "Event.Button.Action", buttonAction ?? words[2]);
+        setOrCreate(NSPanel_Path + "Event.Button.Value", words[4] != undefined ? words[4] : null);
+        setOrCreate(NSPanel_Path + "Event.Button.Id", id);
 
         if (Debug) {
             log('HandleButtonEvent buttonAction: ' + buttonAction, 'info');
@@ -7359,6 +7363,14 @@ function HandleButtonEvent(words: any): void {
     }
 }
 
+function setOrCreate(id : string, value : any, forceCreation: boolean = true, common: Partial<iobJS.StateCommon> = { }, callback?: iobJS.SetStateCallback) {
+    if (!existsState(id)) {
+         createState(id, value, forceCreation, common, callback);
+    } else {
+        setState(id, value);
+    }
+}
+				   
 //Determination of page navigation (CustomSend-Payload)
 function GetNavigationString(pageId: number): string {
     try {


### PR DESCRIPTION
Whenever a button is pressed there is no event triggered which lets the user easily implement triggers on this event. This PR adds the functionality that the current button event is written to NSPanel objects structures as states under `0_userdata.0.NSPanel.1.Event.Button`:
- Action - whatever button was pressed (button, media-OnOff, volumeSlider, ...)
- Value -  auxillary value for this action (e.g. action `volumeSlider` - `Value` holds the value the slider was moved to)
- Id
  - Action == `button` - Id of the alias the button is connected to
  - else - Id of the current page item or the page to navigate to