### PR TITLE
Turn App to ADBase APP

### DIFF
--- a/HMI/US/portrait/diff-filtered.txt
+++ b/HMI/US/portrait/diff-filtered.txt
@@ -1,4 +1,4 @@
-+++ /dev/fd/62	2024-01-20 23:31:31.560618969 +0000
++++ /dev/fd/62	2024-02-16 07:03:00.246651838 +0000
 +I/n2t-out/Program.s.txt
 ++ HMI/US/portrait/n2t-out/Program.s.txt
 +1 +12,11 @@

--- a/apps/nspanel-lovelace-ui/luibackend/apis.py
+++ b/apps/nspanel-lovelace-ui/luibackend/apis.py
@@ -1,2 +1,3 @@
 ha_api = None
 mqtt_api = None
+ad_api = None

--- a/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
+++ b/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
@@ -1,4 +1,4 @@
-import hassapi as hass
+import adbase as ad
 
 from luibackend.config import LuiBackendConfig
 from luibackend.controller import LuiController
@@ -7,14 +7,17 @@ from luibackend.updater import Updater
 
 import apis
 
-class NsPanelLovelaceUIManager(hass.Hass):
+class NsPanelLovelaceUIManager(ad.ADBase):
 
     def initialize(self):
-        self.log('Starting')
-        apis.ha_api   = self
+        self.adapi = self.get_ad_api()
+        self.adapi.log('Starting')
+        
+        apis.ha_api   = self.get_plugin_api("HASS")
         apis.mqtt_api = self.get_plugin_api("MQTT")
+        apis.ad_api = self.adapi
 
-        cfg = self._cfg = LuiBackendConfig(self, self.args["config"])
+        cfg = self._cfg = LuiBackendConfig(apis.ha_api, self.args["config"])
 
         use_api = cfg.get("use_api") == True
 
@@ -23,7 +26,7 @@ class NsPanelLovelaceUIManager(hass.Hass):
         api_panel_name = cfg.get("panelName")
         api_device_id = cfg.get("panelDeviceId")
 
-        mqttsend = LuiMqttSender(self, use_api, topic_send, api_panel_name)
+        mqttsend = LuiMqttSender(apis.ha_api, use_api, topic_send, api_panel_name)
 
         controller = LuiController(cfg, mqttsend.send_mqtt_msg)
         
@@ -41,11 +44,11 @@ class NsPanelLovelaceUIManager(hass.Hass):
         desired_tasmota_driver_url       = cfg._config.get("berryURL",         "https://raw.githubusercontent.com/joBr99/nspanel-lovelace-ui/main/tasmota/autoexec.be")
 
         mode = cfg.get("updateMode")
-        updater = Updater(self.log, mqttsend, topic_send, mode, desired_display_firmware_version, model, desired_display_firmware_url, desired_tasmota_driver_version, desired_tasmota_driver_url)
+        updater = Updater(self.adapi.log, mqttsend, topic_send, mode, desired_display_firmware_version, model, desired_display_firmware_url, desired_tasmota_driver_version, desired_tasmota_driver_url)
         
         # Request Tasmota Driver Version
         updater.request_berry_driver_version()
 
         LuiMqttListener(use_api, topic_recv, api_panel_name, api_device_id, controller, updater)
 
-        self.log(f'Started ({version})')
+        self.adapi.log(f'Started ({version})')


### PR DESCRIPTION
This PR converts the app into an AD base app instead of HASS app. This has the following benefits:

- Since more than one plugin is in use, it helps make it easier to write
- Some of us like myself don't use the "default" namespace of HASS (I got up to 8), so it ensures the right namespace is picked up automatically 