### PR TITLE
Turn app into AD Base app

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/apis.py
+++ b/apps/nspanel-lovelace-ui/luibackend/apis.py
@@ -1,2 +1,3 @@
 ha_api = None
 mqtt_api = None
+ad_api = None


### PR DESCRIPTION
This PR converts the app into an AD base app instead of HASS app. This has the following benefits:

- Since more than one plugin is in use, it helps make it easier to write
- Some of us like myself don't use the "default" namespace of HASS (I got up to 8), so it ensures the right namespace is picked up automatically