### PR TITLE
Current Card access

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/apis.py
+++ b/apps/nspanel-lovelace-ui/luibackend/apis.py
@@ -1,2 +1,3 @@
 ha_api = None
 mqtt_api = None
+ad_api = None

--- a/apps/nspanel-lovelace-ui/luibackend/config.py
+++ b/apps/nspanel-lovelace-ui/luibackend/config.py
@@ -132,6 +132,7 @@ class LuiBackendConfig(object):
             'sleepTrackingZones': ["not_home", "off"],
             'sleepOverride': None,
             'locale': "en_US",
+            'quiet': True,
             'timeFormat': "%H:%M",
             'dateFormatBabel': "full",
             'dateAdditionalTemplate': "",

--- a/apps/nspanel-lovelace-ui/luibackend/controller.py
+++ b/apps/nspanel-lovelace-ui/luibackend/controller.py
@@ -458,3 +458,9 @@ class LuiController(object):
             apis.ha_api.get_entity(entity_id).call_service("pause")
         if button_type == "timer-finish":
             apis.ha_api.get_entity(entity_id).call_service("finish")
+            
+    @property
+    def current_card(self) -> str:
+        """Used to get the current card"""
+
+        return self._current_card

--- a/apps/nspanel-lovelace-ui/luibackend/mqtt.py
+++ b/apps/nspanel-lovelace-ui/luibackend/mqtt.py
@@ -77,12 +77,13 @@ class LuiMqttListener(object):
                 self._controller.detail_open(msg[2], msg[3])
 
 class LuiMqttSender(object):
-    def __init__(self, api, use_api, topic_send, api_panel_name):
+    def __init__(self, api, use_api, topic_send, api_panel_name, quiet):
         self._ha_api = api
         self._use_api = use_api
         self._topic_send = topic_send
         self._api_panel_name = api_panel_name
         self._prev_msg = ""
+        self._quiet = quiet
 
     def send_mqtt_msg(self, msg, topic=None, force=False):
         if not force and self._prev_msg == msg:
@@ -90,7 +91,9 @@ class LuiMqttSender(object):
             return
         self._prev_msg = msg
 
-        apis.ha_api.log(f"Sending Message: {msg}")
+        if self._quiet is False:
+            apis.ha_api.log(f"Sending Message: {msg}")
+            
         if self._use_api:
             apis.ha_api.call_service(service="esphome/" + self._api_panel_name + "_nspanelui_api_call", command=2, data=msg)
         else:

--- a/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
+++ b/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
@@ -24,8 +24,9 @@ class NsPanelLovelaceUIManager(ad.ADBase):
         topic_recv = cfg.get("panelRecvTopic")
         api_panel_name = cfg.get("panelName")
         api_device_id = cfg.get("panelDeviceId")
+        quiet = cfg.get("quiet")
 
-        mqttsend = LuiMqttSender(apis.ha_api, use_api, topic_send, api_panel_name)
+        mqttsend = LuiMqttSender(apis.ha_api, use_api, topic_send, api_panel_name, quiet)
 
         controller = LuiController(cfg, mqttsend.send_mqtt_msg)
         

--- a/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
+++ b/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
@@ -49,7 +49,7 @@ class NsPanelLovelaceUIManager(ad.ADBase):
         # Request Tasmota Driver Version
         updater.request_berry_driver_version()
 
-        LuiMqttListener(use_api, topic_recv, api_panel_name, api_device_id, controller, updater)
+        LuiMqttListener(use_api, topic_recv, api_panel_name, api_device_id, self._controller, updater)
 
         self.adapi.log(f'Started ({version})')
         

--- a/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
+++ b/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
@@ -1,5 +1,4 @@
 import adbase as ad
-import adbase as ad
 
 from luibackend.config import LuiBackendConfig
 from luibackend.controller import LuiController

--- a/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
+++ b/apps/nspanel-lovelace-ui/nspanel-lovelace-ui.py
@@ -28,7 +28,7 @@ class NsPanelLovelaceUIManager(ad.ADBase):
 
         mqttsend = LuiMqttSender(apis.ha_api, use_api, topic_send, api_panel_name, quiet)
 
-        controller = LuiController(cfg, mqttsend.send_mqtt_msg)
+        self._controller = LuiController(cfg, mqttsend.send_mqtt_msg)
         
         desired_tasmota_driver_version   = 8
         desired_display_firmware_version = 53
@@ -52,3 +52,9 @@ class NsPanelLovelaceUIManager(ad.ADBase):
         LuiMqttListener(use_api, topic_recv, api_panel_name, api_device_id, controller, updater)
 
         self.adapi.log(f'Started ({version})')
+        
+    @property
+    def current_card(self) -> str:
+        """Used to get the panel's current card"""
+        
+        return self._controller.current_card.key


### PR DESCRIPTION
This gives the ability for other apps to access what the current card is, in other to process other logic.

For example shutdown shows a hidden card to confirm, and can use the buttons to either accept or reject. 

Same buttons used to control lights, when not on the accept/reject page

This is on the bases the other PR #1183 is accepted