### PR TITLE
Added sanity checks to definition of mrIcons for Screensaver

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -2027,13 +2027,25 @@ async function SubscribeMRIcons() {
         arr = config.mrIcon1ScreensaverEntity.ScreensaverEntityValue != null ? [...arr, config.mrIcon1ScreensaverEntity.ScreensaverEntityValue] : arr;
         if (arr.length > 0) {
             on({ id: arr, change: 'ne' }, async function (obj) {
-                if (obj.id!.substring(0, 4) == 'mqtt') {
-                    let Button = obj.id!.split('.');
-                    if (getState(NSPanel_Path + 'Relay.' + Button[Button.length - 1].substring(5, 6)).val != obj.state.val) {
-                        await setStateAsync(NSPanel_Path + 'Relay.' + Button[Button.length - 1].substring(5, 6), obj.state.val == 'ON' ? true : false);
+                try {
+                    if (obj.id!.substring(0, 4) == 'mqtt') {
+                        let Button = obj.id!.split('.');
+
+                        let relayPath = NSPanel_Path + 'Relay.' + Button[Button.length - 1].substring(5, 6);
+                        let relayState = getState(relayPath);
+
+                        if (!relayState) {
+                            log('State not found: ' + relayPath, 'warn');
+                        } else if (relayState.val != obj.state.val) {
+                            await setStateAsync(relayPath, obj.state.val == 'ON' ? true : false);
+                        }
+
+                    } else {
+                        HandleScreensaverStatusIcons();
                     }
-                } else {
-                    HandleScreensaverStatusIcons();
+                }
+                catch (err: any) {
+                    log('Error in on callback: ' + err.message, 'warn');
                 }
             });
         }
@@ -2041,13 +2053,24 @@ async function SubscribeMRIcons() {
         arr = config.mrIcon2ScreensaverEntity.ScreensaverEntityValue != null ? [...arr, config.mrIcon2ScreensaverEntity.ScreensaverEntityValue] : arr;
         if (arr.length > 0) {
             on({ id: arr, change: 'ne' }, async function (obj) {
-                if (obj.id!.substring(0, 4) == 'mqtt') {
-                    let Button = obj.id!.split('.');
-                    if (getState(NSPanel_Path + 'Relay.' + Button[Button.length - 1].substring(5, 6)).val != obj.state.val) {
-                        await setStateAsync(NSPanel_Path + 'Relay.' + Button[Button.length - 1].substring(5, 6), obj.state.val == 'ON' ? true : false);
+                try {
+                    if (obj.id!.substring(0, 4) == 'mqtt') {
+                        let Button = obj.id!.split('.');
+
+                        let relayPath = NSPanel_Path + 'Relay.' + Button[Button.length - 1].substring(5, 6);
+                        let relayState = getState(relayPath);
+
+                        if (!relayState) {
+                            log('State not found: ' + relayPath, 'warn');
+                        } else if (relayState.val != obj.state.val) {
+                            await setStateAsync(relayPath, obj.state.val == 'ON' ? true : false);
+                        }
+                    } else {
+                        HandleScreensaverStatusIcons();
                     }
-                } else {
-                    HandleScreensaverStatusIcons();
+                }
+                catch (err: any) {
+                    log('Error in on callback: ' + err.message, 'warn');
                 }
             });
         }


### PR DESCRIPTION
Since some months ago there is a problem regarding the mrIcons[1,2] of the screenSaverEntities. Specifically i see crashes of the javascript-adapter of Iobroker, when values of an OpenDTU instance shall be displayed as mrIcon[1,2]ScreensaverEntity.ScreensaverEntityValue. It seems like the error handling is not good enough yet.
After applying the proposed changes, i see no crashes of the javascript-adapter anymore. Before, as an example, i saw this stack trace: 
<img width="1307" alt="Ohne Titel 8" src="https://github.com/user-attachments/assets/eac464f7-9b25-48f0-8ba0-2e51d285823d" />
This relates to a broken path to one of the relays and a broken promise. Both are caught in this proposed change.