### PR TITLE
Improve performance by deduplicating registered callbacks

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/controller.py
+++ b/apps/nspanel-lovelace-ui/luibackend/controller.py
@@ -151,7 +151,7 @@ class LuiController(object):
         items = self._config.get_all_entity_names()
         apis.ha_api.log(f"gtest123: {items}")
         prefixes = ("navigate.", "delete", "iText")
-        items = [x for x in items if not (x is None or x.startswith(prefixes))]
+        items = set([x for x in items if not (x is None or x.startswith(prefixes))])
         apis.ha_api.log(f"Registering callbacks for the following items: {items}")
         for item in items:
             if apis.ha_api.entity_exists(item):


### PR DESCRIPTION
In typical configuration with multiple day forecast being shown on screensaver will lead to callback for weather entity being registered 5 times which means 5x as many weatherUpdate messages (+ related messages), meaning 15 instead of 3 messages are sent which takes non trivial amount of time and affects performance, this is especially visible if sairon's esphome version on the nspanels.
