### PR TITLE
Fix weather entities reverting to daily forecast

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -388,11 +388,12 @@ class LuiPagesGen(object):
             entityTypePanel = "text"
             unit = get_attr_safe(entity, "temperature_unit", "")
             rt = None
+            index = item.stype
             if type(item.stype) == str and ":" in item.stype and len(item.stype.split(":")) == 2:
                 spintstr = item.stype.split(":")
                 rt = spintstr[0]
-                item.stype = int(spintstr[1])
-            if type(item.stype) == int:
+                index = int(spintstr[1])
+            if type(index) == int:
                 bits = get_attr_safe(entity, "supported_features", 0b0)
                 if not rt:
                     rt = "daily"
@@ -407,8 +408,8 @@ class LuiPagesGen(object):
                     "weather/get_forecasts", target={"entity_id": entityId}, service_data={"type": rt}
                 )
                 forecast = results.get("result", {}).get("response", {}).get(entityId, {}).get('forecast') or entity.attributes.get('forecast', [])
-                if len(forecast) >= item.stype:
-                    day_forecast = forecast[item.stype]
+                if len(forecast) >= index:
+                    day_forecast = forecast[index]
                     fdate = dp.parse(day_forecast['datetime'])
                     global babel_spec
                     if babel_spec is not None:


### PR DESCRIPTION
My screensaver has the following config:

```
    screensaver:
      entities:
      - entity: weather.home
      - entity: weather.home
        type: hourly:0
        name: '%-I %p'
      - entity: weather.home
        type: hourly:1
        name: '%-I %p'
      - entity: weather.home
        type: 0
      - entity: weather.home
        type: 1
```

Most noticeably, I'd see the label on the hourly forecast always saying "12 PM". This was super elusive to track down, as whenever I touched something, even unrelated, it seemed to fix itself.

Eventually I noticed that the forecast was also being derived from the daily forecast, which was a useful clue.

Turns out pages.py was mutating the item config. This meant that first time through, the screensaver would render cleanly. But after that, type would have changed from "hourly:1" to 1, which then defaults to daily

This PR makes sure we don't modify `item`