### PR TITLE
Fix: Display waking from screensaver on entity changes after thermostat interaction

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -8780,7 +8780,11 @@ function unsubscribePowerSubscriptions (): void {
  * @returns {void}
  */
 function subscribePowerSubscriptions (id: string): void {
-    on({id: id + '.ACTUAL', change: 'ne'}, async function () {
+    const subscriptionKey = 'power_' + id + '.ACTUAL';
+    if (subscriptions.hasOwnProperty(subscriptionKey)) {
+        return;
+    }
+    subscriptions[subscriptionKey] = on({id: id + '.ACTUAL', change: 'ne'}, async function () {
         (function () {
             if (timeoutPower) {
                 clearTimeout(timeoutPower);


### PR DESCRIPTION
The subscribePowerSubscriptions() function was creating subscriptions via on() without storing the subscription ID in the subscriptions object. This caused UnsubscribeWatcher() to be unable to remove the subscription when the screensaver activated, leaving it active and triggering GeneratePage() on any entity change.

Changes:
- Store subscription in subscriptions object with key 'power_<id>.ACTUAL'
- Add hasOwnProperty check to prevent duplicate subscriptions