### PR TITLE
fix: use locale-aware date formats instead of parseFormat ...

### DIFF
--- a/ioBroker/NsPanelTs.ts
+++ b/ioBroker/NsPanelTs.ts
@@ -12538,7 +12538,7 @@ function HandleScreensaverUpdate (): void {
 			                }
 			            } else if (typeof val == 'string') {
 			                iconColor = GetScreenSaverEntityColor(leftScreensaverEntity);
-			                let pformat = parseFormat(val);
+			                let pformat = ['L', 'LL', 'LLL', 'LLLL'];
 			                if (Debug) log('moments.js --> Datum ' + val + ' valid?: ' + moment(val, pformat, true).isValid(), 'info');
 			                if (moment(val, pformat, true).isValid()) {
 			                    let DatumZeit = moment(val, pformat).unix(); // Umwandlung in Unix Time-Stamp
@@ -12884,7 +12884,7 @@ function HandleScreensaverUpdate (): void {
                     } else if (typeof val == 'string') {
                         iconColor = GetScreenSaverEntityColor(config.bottomScreensaverEntity[4]);
 
-                        let pformat = parseFormat(val);
+                        let pformat = ['L', 'LL', 'LLL', 'LLLL'];
                         if (Debug) log('moments.js --> Datum ' + val + ' valid?: ' + moment(val, pformat, true).isValid(), 'info');
                         if (moment(val, pformat, true).isValid()) {
                             let DatumZeit = moment(val, pformat).unix(); // Conversion to Unix time stamp
@@ -12955,7 +12955,7 @@ function HandleScreensaverUpdate (): void {
                         }
                     } else if (typeof val == 'string') {
                         iconColor = GetScreenSaverEntityColor(entity);
-                        let pformat = parseFormat(val);
+                        let pformat = ['L', 'LL', 'LLL', 'LLLL'];
                         if (Debug) log('moments.js --> Datum ' + val + ' valid?: ' + moment(val, pformat, true).isValid(), 'info');
                         if (moment(val, pformat, true).isValid()) {
                             let DatumZeit = moment(val, pformat).unix(); // Conversion to Unix time stamp


### PR DESCRIPTION
…to avoid misinterpretations when dateformat is not set

parseFormat() guessed the date format from the string which caused wrong interpretation e.g. '07.04.2026' was read as Jan 7 instead of Apr 7 in some locales. Replace with moment locale tokens ['L','LL', 'LLL','LLLL'] which are resolved based on the already configured moment.locale() from Config.locale.