### PR TITLE
Fix: Use Kelvin instead of Mireds for color_temp

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/controller.py
+++ b/apps/nspanel-lovelace-ui/luibackend/controller.py
@@ -375,8 +375,8 @@ class LuiController(object):
         if button_type == "colorTempSlider":
             entity = apis.ha_api.get_entity(entity_id)
             #scale 0-100 from slider to color range of lamp
-            color_val = scale(int(value), (0, 100), (entity.attributes['min_mireds'], entity.attributes['max_mireds']))
-            apis.ha_api.get_entity(entity_id).call_service("turn_on", color_temp=color_val)
+            color_temp_val = scale(int(value), (0, 100), (entity.attributes['max_color_temp_kelvin'], entity.attributes['min_color_temp_kelvin']))
+            apis.ha_api.get_entity(entity_id).call_service("turn_on", color_temp_kelvin=color_temp_val)
         if button_type == "colorWheel":
             apis.ha_api.log(value)
             value = value.split('|')

--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -893,9 +893,9 @@ class LuiPagesGen(object):
             else:
                 brightness = "disable"
             if "color_temp" in supported_color_modes:
-                if color_temp := entity.attributes.get("color_temp"):
+                if color_temp := entity.attributes.get("color_temp_kelvin"):
                     # scale ha color temp range to 0-100
-                    color_temp = int(scale(color_temp, (entity.attributes['min_mireds'], entity.attributes['max_mireds']),(0, 100)))
+                    color_temp = int(scale(color_temp, (entity.attributes['max_color_temp_kelvin'], entity.attributes['min_color_temp_kelvin']),(0, 100)))
                 else:
                     color_temp = "unknown"
             else:


### PR DESCRIPTION
Fixes the color temperature slider mapping. Following the mireds-to-Kelvin deprecation in HA 2026.3 (https://github.com/home-assistant/core/pull/161777), the UI slider was hidden due to a failed attribute lookup. This PR migrates the mapping and service calls to color_temp_kelvin

