### PR TITLE
Fix off-by-one crash in forecast

### DIFF
--- a/apps/nspanel-lovelace-ui/luibackend/pages.py
+++ b/apps/nspanel-lovelace-ui/luibackend/pages.py
@@ -410,7 +410,7 @@ class LuiPagesGen(object):
                     "weather/get_forecasts", target={"entity_id": entityId}, service_data={"type": rt}
                 )
                 forecast = results.get("result", {}).get("response", {}).get(entityId, {}).get('forecast') or entity.attributes.get('forecast', [])
-                if len(forecast) >= index:
+                if len(forecast) > index:
                     day_forecast = forecast[index]
                     fdate = dp.parse(day_forecast['datetime'])
                     global babel_spec


### PR DESCRIPTION
I was seeing these errors when displaying my hourly forecasts, since python uses 0-based indexing this check was off-by-one at the extreme case

```
2026-05-23 15:50:09.577870 ERROR nspanel-1:   IndexError: list index out of range
2026-05-23 15:50:09.585750 ERROR nspanel-1:     File "/usr/lib/python3.12/site-packages/appdaemon/threads.py", line 1095, in safe_callback
2026-05-23 15:50:09.586318 ERROR nspanel-1:       funcref()
2026-05-23 15:50:09.586990 ERROR nspanel-1:     File "/homeassistant/appdaemon/apps/nspanel-lovelace-ui/luibackend/controller.py", line 174, in state_change_callback
2026-05-23 15:50:09.587543 ERROR nspanel-1:       self._pages_gen.render_card(self._current_card, send_page_type=False)
2026-05-23 15:50:09.588039 ERROR nspanel-1:     File "/homeassistant/appdaemon/apps/nspanel-lovelace-ui/luibackend/pages.py", line 861, in render_card
2026-05-23 15:50:09.588629 ERROR nspanel-1:       self.update_screensaver_weather(theme)
2026-05-23 15:50:09.589169 ERROR nspanel-1:     File "/homeassistant/appdaemon/apps/nspanel-lovelace-ui/luibackend/pages.py", line 152, in update_screensaver_weather
2026-05-23 15:50:09.589692 ERROR nspanel-1:       item_str += self.generate_entities_item(item, "cardEntities", mask=["type", "entityId"])
2026-05-23 15:50:09.590319 ERROR nspanel-1:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-23 15:50:09.590731 ERROR nspanel-1:     File "/homeassistant/appdaemon/apps/nspanel-lovelace-ui/luibackend/pages.py", line 417, in generate_entities_item
2026-05-23 15:50:09.591174 ERROR nspanel-1:       raise e
2026-05-23 15:50:09.591597 ERROR nspanel-1:     File "/homeassistant/appdaemon/apps/nspanel-lovelace-ui/luibackend/pages.py", line 412, in generate_entities_item
2026-05-23 15:50:09.592025 ERROR nspanel-1:       day_forecast = forecast[item.stype]
2026-05-23 15:50:09.592401 ERROR nspanel-1:                      ~~~~~~~~^^^^^^^^^^^^
2026-05-23 15:50:09.592875 ERROR nspanel-1: ===========================================================================
```